### PR TITLE
[FEAT] 회원가입 API 및 User 엔티티 구현 (#3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.0' // 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.1' // 공통 라이브러리 의존성 추가
 
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
 

--- a/src/main/java/com/followme/userserver/UserserverApplication.java
+++ b/src/main/java/com/followme/userserver/UserserverApplication.java
@@ -1,7 +1,11 @@
 package com.followme.userserver;
 
+import java.util.Optional;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
@@ -12,5 +16,10 @@ public class UserserverApplication {
 		SpringApplication.run(UserserverApplication.class, args);
 	}
 	
+	@Bean
+    public AuditorAware<String> auditorAware() {
+        // 임시로 "system" 이라는 이름을 사용
+        return () -> Optional.of("system");
+    }
 
 }

--- a/src/main/java/com/followme/userserver/UserserverApplication.java
+++ b/src/main/java/com/followme/userserver/UserserverApplication.java
@@ -2,12 +2,15 @@ package com.followme.userserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class UserserverApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(UserserverApplication.class, args);
 	}
+	
 
 }

--- a/src/main/java/com/followme/userserver/application/dto/UserRegisterRequestDto.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserRegisterRequestDto.java
@@ -1,0 +1,42 @@
+package com.followme.userserver.application.dto;
+
+import com.followme.userserver.domain.enums.UserRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisterRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^[a-z0-9]{4,10}$")
+    private String username;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$")
+    private String password;
+
+    @NotBlank
+    private String name;
+
+    private String address;
+    
+    private String phone;
+
+    @NotBlank
+    private String slackId;
+
+    @NotNull
+    private UserRole role;
+
+    private UUID hubId;
+    
+    private UUID vendorId;
+}

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -1,0 +1,43 @@
+package com.followme.userserver.application.service;
+
+import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserStatus;
+import com.followme.userserver.domain.repository.UserRepository;
+import com.followme.userserver.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerUser(UserRegisterRequestDto request) {
+        
+        // 1. 아이디 중복 검증 
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw UserErrorCode.DUPLICATE_USERNAME.toException(); 
+        }
+
+        // 2. DTO 데이터를 바탕으로 엔티티 조립
+        User newUser = User.builder()
+                .username(request.getUsername())
+                .password(request.getPassword()) 
+                .name(request.getName())
+                .address(request.getAddress())
+                .phone(request.getPhone())
+                .slackId(request.getSlackId())
+                .role(request.getRole())
+                .status(UserStatus.PENDING)
+                .hubId(request.getHubId())
+                .vendorId(request.getVendorId())
+                .build();
+
+        // 3. DB에 저장
+        userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -26,7 +26,6 @@ public class UserService {
         // 2. DTO 데이터를 바탕으로 엔티티 조립
         User newUser = User.builder()
                 .username(request.getUsername())
-                .password(request.getPassword()) 
                 .name(request.getName())
                 .address(request.getAddress())
                 .phone(request.getPhone())

--- a/src/main/java/com/followme/userserver/config/SecurityConfig.java
+++ b/src/main/java/com/followme/userserver/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.followme.userserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/users/register").permitAll() // 회원가입은 인증 없이 접근 허용
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -11,7 +11,7 @@ import lombok.*;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_users")
+@Table(name = "p_user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -25,9 +25,6 @@ public class User extends BaseAudit {
     @Column(nullable = false, unique = true, length = 10)
     private String username;
 
-    @Column(nullable = false, length = 100)
-    private String password;
-
     @Column(nullable = false, length = 50)
     private String name;
 

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -1,0 +1,69 @@
+package com.followme.userserver.domain.entity;
+
+
+import com.followMe.common.entity.BaseAudit; 
+
+import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.enums.UserStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 10)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 255)
+    private String address;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(name = "slack_id", nullable = false, length = 50)
+    private String slackId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
+    @Column(name = "hub_id")
+    private UUID hubId;
+
+    @Column(name = "vendor_id")
+    private UUID vendorId;
+
+    public void approve() {
+        this.status = UserStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = UserStatus.REJECTED;
+    }
+
+    public void deleteUser(String deletedByUserId) {
+        this.status = UserStatus.DELETED;
+        super.softDelete(deletedByUserId); 
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/enums/UserRole.java
+++ b/src/main/java/com/followme/userserver/domain/enums/UserRole.java
@@ -1,0 +1,8 @@
+package com.followme.userserver.domain.enums;
+
+public enum UserRole {
+    MASTER,     // 마스터 관리자
+    HUB,        // 허브 관리자
+    DELIVERY,   // 배송 담당자
+    VENDOR      // 업체 담당자
+}

--- a/src/main/java/com/followme/userserver/domain/enums/UserStatus.java
+++ b/src/main/java/com/followme/userserver/domain/enums/UserStatus.java
@@ -1,0 +1,8 @@
+package com.followme.userserver.domain.enums;
+
+public enum UserStatus {
+    PENDING,    // 승인 대기 (가입 시 기본값)
+    APPROVED,   // 승인 완료
+    REJECTED,   // 승인 거절
+    DELETED     // 탈퇴/삭제
+}

--- a/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
+++ b/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.followme.userserver.domain.repository;
+
+import com.followme.userserver.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    
+    boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/followme/userserver/exception/UserErrorCode.java
+++ b/src/main/java/com/followme/userserver/exception/UserErrorCode.java
@@ -1,0 +1,20 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    
+    // User 서비스만의 고유 에러 코드
+    DUPLICATE_USERNAME("U001", "이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT), // 409 Conflict
+    USER_NOT_FOUND("U002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),     // 404 Not Found
+    INVALID_PASSWORD("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED); // 401 Unauthorized
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.followme.userserver.presentation.controller;
+
+import com.followMe.common.response.ApiResponse;
+import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.application.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody UserRegisterRequestDto request) {
+        
+        userService.registerUser(request);
+
+        return ApiResponse.created();
+    }
+}


### PR DESCRIPTION
📌 관련 이슈
close #3

💡 작업 내용
User 엔티티 및 계정 상태/권한 관리를 위한 Enum (UserRole, UserStatus) 구현

클라이언트 요청 검증용 UserRegisterRequestDto 생성 (정규식을 통한 아이디/비밀번호 명세 조건 확인)

아이디 중복 검증 및 DB 접근을 위한 UserRepository 추가

UserController 및 UserService 회원가입 비즈니스 로직 구현 (가입 시 status 기본값 PENDING 서버 내 강제 세팅)

common-lib 규격에 맞춘 사용자 도메인 전용 예외 처리 (UserErrorCode) 추가 및 적용

원활한 테스트와 향후 확장을 위한 임시 SecurityConfig (회원가입 API 인증 해제) 및 AuditorAware (임시 작성자 'system') 등록



🔍 변경 이유
MSA 환경에서 사용자 도메인의 가장 기초가 되는 회원가입 로컬 DB 저장 API를 구축하기 위함입니다.

클라이언트 입력값과 시스템 통제값(user_id, status 등)을 엄격하게 분리하여 보안 사고를 방지하기 위해 엔티티와 DTO를 철저히 나누어 설계했습니다.




🧠 기타 참고 사항
Postman 테스트 결과, 로컬 PostgreSQL DB에 정상적으로 데이터가 삽입되고 201 Created 응답이 반환되는 것을 확인했습니다.

가입된 유저 정보를 Keycloak 서버와 동기화(Sync)하고 JWT 인증 필터를 적용하는 로직은 다음 이슈(#4)에서 이어서 진행할 계획입니다.