### PR TITLE
[FEAT] 마이페이지 (프로필 조회, 수정, 비활성화) API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.0' // 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.1' // 공통 라이브러리 의존성 추가
 
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,17 @@ repositories {
     }
 }
 
+ext {
+    // Spring Boot 3.x 버전과 호환되는 Spring Cloud 버전입니다.
+    set('springCloudVersion', "2025.0.0")
+}
+
 dependencies {
 	implementation 'com.followMe:common-lib:1.0.1' // 공통 라이브러리 의존성 추가
 
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
 
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -47,6 +53,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        // 이 블록이 누락된 라이브러리의 버전을 자동으로 주입합니다.
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,13 @@ dependencies {
 
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
 
+	// MapStruct 핵심 라이브러리
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    
+    // Lombok과의 공존을 위한 바인딩 (필수)
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.1' // 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.2' // 공통 라이브러리 의존성 추가
 
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
 

--- a/src/main/java/com/followme/userserver/UserserverApplication.java
+++ b/src/main/java/com/followme/userserver/UserserverApplication.java
@@ -7,6 +7,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @EnableJpaAuditing
 @SpringBootApplication
@@ -18,8 +20,17 @@ public class UserserverApplication {
 	
 	@Bean
     public AuditorAware<String> auditorAware() {
-        // 임시로 "system" 이라는 이름을 사용
-        return () -> Optional.of("system");
-    }
+        return () -> {
+            // 1. 현재 요청을 보낸 사용자의 인증 정보(SecurityContext)를 꺼내옵니다.
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+            // 2. 인증 정보가 없거나, 익명 사용자(회원가입 등 토큰 없이 온 사람)일 경우
+            if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
+                return Optional.of("system"); // 현재는 기본값으로 system으로 기록
+            }
+
+            // 3. 정상적으로 토큰을 들고 온 유저라면, 토큰 안에 있는 유저 ID(이름)를 반환합니다!
+            return Optional.of(authentication.getName());
+        };
+    }
 }

--- a/src/main/java/com/followme/userserver/UserserverApplication.java
+++ b/src/main/java/com/followme/userserver/UserserverApplication.java
@@ -1,7 +1,11 @@
 package com.followme.userserver;
 
+import java.util.Optional;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
@@ -12,5 +16,10 @@ public class UserserverApplication {
 		SpringApplication.run(UserserverApplication.class, args);
 	}
 	
+	@Bean
+    public AuditorAware<String> auditorAware() {
+        // 임시로 "system" 이라는 이름을 사용
+        return () -> Optional.of("system");
+    }
 
 }

--- a/src/main/java/com/followme/userserver/UserserverApplication.java
+++ b/src/main/java/com/followme/userserver/UserserverApplication.java
@@ -2,12 +2,15 @@ package com.followme.userserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class UserserverApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(UserserverApplication.class, args);
 	}
+	
 
 }

--- a/src/main/java/com/followme/userserver/UserserverApplication.java
+++ b/src/main/java/com/followme/userserver/UserserverApplication.java
@@ -1,36 +1,13 @@
 package com.followme.userserver;
 
-import java.util.Optional;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class UserserverApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(UserserverApplication.class, args);
 	}
-	
-	@Bean
-    public AuditorAware<String> auditorAware() {
-        return () -> {
-            // 1. 현재 요청을 보낸 사용자의 인증 정보(SecurityContext)를 꺼내옵니다.
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-            // 2. 인증 정보가 없거나, 익명 사용자(회원가입 등 토큰 없이 온 사람)일 경우
-            if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
-                return Optional.of("system"); // 현재는 기본값으로 system으로 기록
-            }
-
-            // 3. 정상적으로 토큰을 들고 온 유저라면, 토큰 안에 있는 유저 ID(이름)를 반환합니다!
-            return Optional.of(authentication.getName());
-        };
-    }
 }

--- a/src/main/java/com/followme/userserver/application/annotation/CurrentUser.java
+++ b/src/main/java/com/followme/userserver/application/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.followme.userserver.application.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER) // 컨트롤러 파라미터에만 붙일 수 있도록 설정
+@Retention(RetentionPolicy.RUNTIME) // 실행 중에도 유지되도록 설정
+public @interface CurrentUser {
+}

--- a/src/main/java/com/followme/userserver/application/dto/UserRegisterRequestDto.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserRegisterRequestDto.java
@@ -1,0 +1,42 @@
+package com.followme.userserver.application.dto;
+
+import com.followme.userserver.domain.enums.UserRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisterRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^[a-z0-9]{4,10}$")
+    private String username;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$")
+    private String password;
+
+    @NotBlank
+    private String name;
+
+    private String address;
+    
+    private String phone;
+
+    @NotBlank
+    private String slackId;
+
+    @NotNull
+    private UserRole role;
+
+    private UUID hubId;
+    
+    private UUID vendorId;
+}

--- a/src/main/java/com/followme/userserver/application/dto/UserResponseDto.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserResponseDto.java
@@ -1,0 +1,27 @@
+package com.followme.userserver.application.dto;
+
+import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.enums.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDto {
+    private UUID userId;
+    private String username;
+    private String name;
+    private String address;
+    private String phone;
+    private String slackId;
+    private UserRole role;
+    private UserStatus status;
+    private UUID hubId;
+    private UUID vendorId;
+}

--- a/src/main/java/com/followme/userserver/application/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.followme.userserver.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserUpdateRequestDto {
+
+    private String name;
+    private String address;
+    private String phone;
+    private String slackId;
+    
+}

--- a/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
+++ b/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
@@ -1,7 +1,7 @@
 package com.followme.userserver.application.mapper;
 
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
-import com.followme.userserver.application.dto.UserResponseDto;
+import com.followme.userserver.application.dto.UserResponseDto; // 💡 DTO import 추가
 import com.followme.userserver.domain.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -13,5 +13,7 @@ public interface UserMapper {
     @Mapping(target = "status", constant = "PENDING")
     User toEntity(UserRegisterRequestDto request);
 
+    @Mapping(source = "id", target = "userId")
     UserResponseDto toResponseDto(User user);
+    
 }

--- a/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
+++ b/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
@@ -1,7 +1,7 @@
 package com.followme.userserver.application.mapper;
 
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
-import com.followme.userserver.application.dto.UserResponseDto; // 💡 DTO import 추가
+import com.followme.userserver.application.dto.UserResponseDto;
 import com.followme.userserver.domain.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
+++ b/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.followme.userserver.application.mapper;
 
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.application.dto.UserResponseDto;
 import com.followme.userserver.domain.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -11,4 +12,6 @@ public interface UserMapper {
 
     @Mapping(target = "status", constant = "PENDING")
     User toEntity(UserRegisterRequestDto request);
+
+    UserResponseDto toResponseDto(User user);
 }

--- a/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
+++ b/src/main/java/com/followme/userserver/application/mapper/UserMapper.java
@@ -1,0 +1,14 @@
+package com.followme.userserver.application.mapper;
+
+import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.domain.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UserMapper {
+
+    @Mapping(target = "status", constant = "PENDING")
+    User toEntity(UserRegisterRequestDto request);
+}

--- a/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,48 @@
+package com.followme.userserver.application.resolver;
+
+import com.followMe.common.exception.CommonErrorCode;
+import com.followme.userserver.application.annotation.CurrentUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    // Resolver가 언제 동작할지 결정
+    // 파라미터에 @CurrentUser 가 붙어있고, 타입이 String(username)일 때 동작
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAnnotation = parameter.hasParameterAnnotation(CurrentUser.class);
+        boolean isStringType = String.class.isAssignableFrom(parameter.getParameterType());
+        return hasAnnotation && isStringType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증 정보가 없거나, 익명 사용자면 Exception 반환
+        if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
+            throw CommonErrorCode.UNAUTHORIZED.toException(); 
+        }
+
+        // Keycloak Oauth2 리소스 서버를 쓰면 Principal이 Jwt 객체로 들어옵니다.
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Jwt jwt) {
+            // Keycloak이 발급한 토큰의 "preferred_username"을 꺼냅니다.
+            return jwt.getClaimAsString("preferred_username"); 
+        }
+        
+
+        return authentication.getName();
+    }
+}

--- a/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
@@ -3,7 +3,6 @@ package com.followme.userserver.application.resolver;
 import com.followMe.common.exception.BusinessException;
 import com.followMe.common.exception.CommonErrorCode;
 import com.followme.userserver.application.annotation.CurrentUser;
-import com.followme.userserver.exception.UserNotFoundException;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
@@ -1,7 +1,10 @@
 package com.followme.userserver.application.resolver;
 
+import com.followMe.common.exception.BusinessException;
 import com.followMe.common.exception.CommonErrorCode;
 import com.followme.userserver.application.annotation.CurrentUser;
+import com.followme.userserver.exception.UserNotFoundException;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -32,7 +35,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
         // 인증 정보가 없거나, 익명 사용자면 Exception 반환
         if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
-            throw CommonErrorCode.UNAUTHORIZED.toException(); 
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
         }
 
         // Keycloak Oauth2 리소스 서버를 쓰면 Principal이 Jwt 객체로 들어옵니다.

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -1,0 +1,43 @@
+package com.followme.userserver.application.service;
+
+import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserStatus;
+import com.followme.userserver.domain.repository.UserRepository;
+import com.followme.userserver.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerUser(UserRegisterRequestDto request) {
+        
+        // 1. 아이디 중복 검증 
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw UserErrorCode.DUPLICATE_USERNAME.toException(); 
+        }
+
+        // 2. DTO 데이터를 바탕으로 엔티티 조립
+        User newUser = User.builder()
+                .username(request.getUsername())
+                .password(request.getPassword()) 
+                .name(request.getName())
+                .address(request.getAddress())
+                .phone(request.getPhone())
+                .slackId(request.getSlackId())
+                .role(request.getRole())
+                .status(UserStatus.PENDING)
+                .hubId(request.getHubId())
+                .vendorId(request.getVendorId())
+                .build();
+
+        // 3. DB에 저장
+        userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -1,8 +1,8 @@
 package com.followme.userserver.application.service;
 
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.application.mapper.UserMapper;
 import com.followme.userserver.domain.entity.User;
-import com.followme.userserver.domain.enums.UserStatus;
 import com.followme.userserver.domain.repository.UserRepository;
 // 💡 새롭게 만든 예외 클래스들을 import 합니다.
 import com.followme.userserver.exception.DuplicateUsernameException;
@@ -26,6 +26,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final Keycloak keycloak;
+    private final UserMapper userMapper;
 
     @Value("${keycloak.realm}")
     private String realm;
@@ -63,7 +64,7 @@ public class UserService {
         }
 
         // 3. 로컬 DB용 엔티티
-        User newUser = User.create(request);
+        User newUser = userMapper.toEntity(request);
 
         // 4. DB에 저장
         userRepository.save(newUser);

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -15,11 +15,13 @@ import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,7 @@ public class UserService {
         if (userRepository.existsByUsername(request.getUsername())) {
             throw new DuplicateUsernameException();
         }
+
 
         // 2-1. Keycloak에 보낼 유저 정보
         UserRepresentation kcUser = new UserRepresentation();
@@ -65,11 +68,17 @@ public class UserService {
         if (response.getStatus() != 201) {
             throw new KeycloakSyncException();
         }
+        // 3. Keycloak이 방금 생성한 유저의 UUID 추출하기
+        String path = response.getLocation().getPath();
+        String keycloakUserId = path.substring(path.lastIndexOf('/') + 1);
 
-        // 3. 로컬 DB용 엔티티
+        // 4. 로컬 DB용 엔티티
         User newUser = userMapper.toEntity(request);
 
-        // 4. DB에 저장
+        // 5. 뽑아낸 Keycloak ID를 로컬 엔티티의 ID로 강제 주입
+        newUser.setId(UUID.fromString(keycloakUserId));
+
+        // 6. DB에 저장
         userRepository.save(newUser);
     }
 
@@ -103,9 +112,31 @@ public class UserService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(UserNotFoundException::new);
 
-        // 2. 비활성화 비즈니스 로직 호출 (JPA Dirty Checking으로 자동 UPDATE 됨)
-        user.deactivateAccount();
+        // 2. 토큰 인증 객체에서 직접 ID(Keycloak UUID)를 추출
+        String currentTokenUserId = SecurityContextHolder.getContext().getAuthentication().getName();
         
-        // 나중에 Keycloak 서버에도 API를 쏴서 해당 유저를 Disable 시키는 로직이 이곳에 추가되어야 합니다
+        user.deactivateAccount(currentTokenUserId);
+        
+        try {
+            // 3-1. Keycloak에서 해당 username으로 유저 검색
+            List<UserRepresentation> kcUsers = keycloak.realm(realm).users().search(username);
+            
+            if (kcUsers != null && !kcUsers.isEmpty()) {
+                // 검색된 유저(보통 1명) 정보 가져오기
+                UserRepresentation kcUser = kcUsers.get(0); 
+                
+                // 3-2. 상태를 비활성화(Enabled = false)로 변경
+                kcUser.setEnabled(false); 
+                
+                // 3-3. Keycloak 서버에 변경된 정보 업데이트 요청
+                keycloak.realm(realm).users().get(kcUser.getId()).update(kcUser);
+            } else {
+                // Keycloak에 유저가 없는 극히 드문 예외 상황 처리
+                throw new KeycloakSyncException(); 
+            }
+        } catch (Exception e) {
+            // Keycloak 서버 통신 장애 등 예외 발생 시 트랜잭션 롤백을 위해 예외 던지기
+            throw new KeycloakSyncException(); 
+        }
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -96,4 +96,16 @@ public class UserService {
         // 3. 수정된 결과를 다시 DTO로 변환하여 반환
         return userMapper.toResponseDto(user);
     }
+
+    @Transactional
+    public void deactivateMyAccount(String username) {
+        // 1. 유저 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 2. 비활성화 비즈니스 로직 호출 (JPA Dirty Checking으로 자동 UPDATE 됨)
+        user.deactivateAccount();
+        
+        // 나중에 Keycloak 서버에도 API를 쏴서 해당 유저를 Disable 시키는 로직이 이곳에 추가되어야 합니다
+    }
 }

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.followme.userserver.application.service;
 
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
 import com.followme.userserver.application.dto.UserResponseDto;
+import com.followme.userserver.application.dto.UserUpdateRequestDto;
 import com.followme.userserver.application.mapper.UserMapper;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.repository.UserRepository;
@@ -79,6 +80,20 @@ public class UserService {
                 .orElseThrow(UserNotFoundException::new);
 
         // 2. MapStruct를 이용해 Entity -> DTO 변환 후 반환
+        return userMapper.toResponseDto(user);
+    }
+
+    @Transactional
+    public UserResponseDto updateUserProfile(String username, UserUpdateRequestDto request) {
+        
+        // 1. 유저 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 2. 엔티티 비즈니스 메서드 호출 (데이터 수정)
+        user.updateProfile(request);
+
+        // 3. 수정된 결과를 다시 DTO로 변환하여 반환
         return userMapper.toResponseDto(user);
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -26,7 +26,6 @@ public class UserService {
         // 2. DTO 데이터를 바탕으로 엔티티 조립
         User newUser = User.builder()
                 .username(request.getUsername())
-                .password(request.getPassword()) 
                 .name(request.getName())
                 .address(request.getAddress())
                 .phone(request.getPhone())

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -4,7 +4,9 @@ import com.followme.userserver.application.dto.UserRegisterRequestDto;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserStatus;
 import com.followme.userserver.domain.repository.UserRepository;
-import com.followme.userserver.exception.UserErrorCode;
+// 💡 새롭게 만든 예외 클래스들을 import 합니다.
+import com.followme.userserver.exception.DuplicateUsernameException;
+import com.followme.userserver.exception.KeycloakSyncException;
 
 import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
-
     private final Keycloak keycloak;
 
     @Value("${keycloak.realm}")
@@ -34,7 +35,7 @@ public class UserService {
         
         // 1. 아이디 중복 검증 
         if (userRepository.existsByUsername(request.getUsername())) {
-            throw UserErrorCode.DUPLICATE_USERNAME.toException(); 
+            throw new DuplicateUsernameException();
         }
 
         // 2-1. Keycloak에 보낼 유저 정보
@@ -50,7 +51,6 @@ public class UserService {
         credential.setType(CredentialRepresentation.PASSWORD);
         credential.setValue(request.getPassword());
         credential.setTemporary(false);
-
         
         // 2-3. 유저 정보 안에 비밀번호 넣기
         kcUser.setCredentials(List.of(credential));
@@ -59,21 +59,11 @@ public class UserService {
         Response response = keycloak.realm(realm).users().create(kcUser);
 
         if (response.getStatus() != 201) {
-            throw UserErrorCode.KEYCLOAK_SYNC_FAILED.toException();
+            throw new KeycloakSyncException();
         }
 
         // 3. 로컬 DB용 엔티티
-        User newUser = User.builder()
-                .username(request.getUsername())
-                .name(request.getName())
-                .address(request.getAddress())
-                .phone(request.getPhone())
-                .slackId(request.getSlackId())
-                .role(request.getRole())
-                .status(UserStatus.PENDING)
-                .hubId(request.getHubId())
-                .vendorId(request.getVendorId())
-                .build();
+        User newUser = User.create(request);
 
         // 4. DB에 저장
         userRepository.save(newUser);

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -1,12 +1,14 @@
 package com.followme.userserver.application.service;
 
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.application.dto.UserResponseDto;
 import com.followme.userserver.application.mapper.UserMapper;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.repository.UserRepository;
 // 💡 새롭게 만든 예외 클래스들을 import 합니다.
 import com.followme.userserver.exception.DuplicateUsernameException;
 import com.followme.userserver.exception.KeycloakSyncException;
+import com.followme.userserver.exception.UserNotFoundException;
 
 import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
@@ -68,5 +70,15 @@ public class UserService {
 
         // 4. DB에 저장
         userRepository.save(newUser);
+    }
+
+    @Transactional(readOnly = true)
+    public UserResponseDto getUserProfile(String username) {
+        // 1. DB에서 유저 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 2. MapStruct를 이용해 Entity -> DTO 변환 후 반환
+        return userMapper.toResponseDto(user);
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -115,7 +115,7 @@ public class UserService {
         // 2. 토큰 인증 객체에서 직접 ID(Keycloak UUID)를 추출
         String currentTokenUserId = SecurityContextHolder.getContext().getAuthentication().getName();
         
-        user.deactivateAccount(currentTokenUserId);
+        user.deactivateAccount(java.util.UUID.fromString(currentTokenUserId));
         
         try {
             // 3-1. Keycloak에서 해당 username으로 유저 검색

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -5,7 +5,16 @@ import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserStatus;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.UserErrorCode;
+
+import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +24,11 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    private final Keycloak keycloak;
+
+    @Value("${keycloak.realm}")
+    private String realm;
+    
     @Transactional
     public void registerUser(UserRegisterRequestDto request) {
         
@@ -23,7 +37,28 @@ public class UserService {
             throw UserErrorCode.DUPLICATE_USERNAME.toException(); 
         }
 
-        // 2. DTO 데이터를 바탕으로 엔티티 조립
+        // 2-1. Keycloak에 보낼 유저 정보
+        UserRepresentation kcUser = new UserRepresentation();
+        kcUser.setUsername(request.getUsername());
+        kcUser.setEnabled(true);
+
+        // 2-2. Keycloak에 보낼 비밀번호
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue(request.getPassword());
+        credential.setTemporary(false);
+
+        // 2-3. 유저 정보 안에 비밀번호 넣기
+        kcUser.setCredentials(List.of(credential));
+
+        // 2-4. 핫라인으로 API 전송
+        Response response = keycloak.realm(realm).users().create(kcUser);
+
+        if (response.getStatus() != 201) {
+            throw UserErrorCode.KEYCLOAK_SYNC_FAILED.toException();
+        }
+
+        // 3. 로컬 DB용 엔티티
         User newUser = User.builder()
                 .username(request.getUsername())
                 .name(request.getName())
@@ -36,7 +71,7 @@ public class UserService {
                 .vendorId(request.getVendorId())
                 .build();
 
-        // 3. DB에 저장
+        // 4. DB에 저장
         userRepository.save(newUser);
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/UserService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserService.java
@@ -41,6 +41,9 @@ public class UserService {
         UserRepresentation kcUser = new UserRepresentation();
         kcUser.setUsername(request.getUsername());
         kcUser.setEnabled(true);
+        kcUser.setLastName(request.getName());
+        kcUser.setFirstName("."); // Keycloak은 firstName이 필수라서 임의로 넣어줍니다.
+        kcUser.setEmail(request.getUsername() + "@test.com"); // Keycloak은 이메일이 필수라서 임의로 넣어줍니다.
 
         // 2-2. Keycloak에 보낼 비밀번호
         CredentialRepresentation credential = new CredentialRepresentation();
@@ -48,6 +51,7 @@ public class UserService {
         credential.setValue(request.getPassword());
         credential.setTemporary(false);
 
+        
         // 2-3. 유저 정보 안에 비밀번호 넣기
         kcUser.setCredentials(List.of(credential));
 

--- a/src/main/java/com/followme/userserver/config/JpaAuditConfig.java
+++ b/src/main/java/com/followme/userserver/config/JpaAuditConfig.java
@@ -1,0 +1,32 @@
+package com.followme.userserver.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+
+    private static final UUID SYSTEM_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+    @Bean
+    public AuditorAware<UUID> auditorAware() {
+        return () -> {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null || !auth.isAuthenticated() || auth.getPrincipal().equals("anonymousUser")) {
+                return Optional.of(SYSTEM_UUID);
+            }
+            try {
+                return Optional.of(UUID.fromString(auth.getName()));
+            } catch (IllegalArgumentException e) {
+                return Optional.of(SYSTEM_UUID);
+            }
+        };
+    }
+}

--- a/src/main/java/com/followme/userserver/config/KeycloakConfig.java
+++ b/src/main/java/com/followme/userserver/config/KeycloakConfig.java
@@ -1,0 +1,39 @@
+package com.followme.userserver.config;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KeycloakConfig {
+
+    @Value("${keycloak.server-url}")
+    private String serverUrl;
+
+    @Value("${keycloak.admin.realm}")
+    private String adminRealm;
+
+    @Value("${keycloak.admin.client-id}")
+    private String clientId;
+
+    @Value("${keycloak.admin.username}")
+    private String username;
+
+    @Value("${keycloak.admin.password}")
+    private String password;
+
+    @Bean
+    public Keycloak keycloak() {
+        return KeycloakBuilder.builder()
+                .serverUrl(serverUrl)
+                .realm(adminRealm)
+                .grantType(OAuth2Constants.PASSWORD)
+                .clientId(clientId)
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/followme/userserver/config/SecurityConfig.java
+++ b/src/main/java/com/followme/userserver/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.followme.userserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/users/register").permitAll() // 회원가입은 인증 없이 접근 허용
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/src/main/java/com/followme/userserver/config/SecurityConfig.java
+++ b/src/main/java/com/followme/userserver/config/SecurityConfig.java
@@ -2,8 +2,10 @@ package com.followme.userserver.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -13,11 +15,21 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
+            .csrf(csrf -> csrf.disable()) 
+            
+            // 1. 세션을 사용하지 않고(Stateless), 오직 JWT 토큰으로만 인증하도록 설정합니다.
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            
+            // 2. 권한 설정
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/users/register").permitAll() // 회원가입은 인증 없이 접근 허용
+                .requestMatchers("/api/v1/users/register").permitAll()
                 .anyRequest().authenticated()
-            );
+            )
+            
+            // 3. OAuth2 리소스 서버 (JWT 검증) 기능 활성화!
+            // 토큰의 유효 기간, 위조 여부를 검사.
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
         return http.build();
     }
 }

--- a/src/main/java/com/followme/userserver/config/WebConfig.java
+++ b/src/main/java/com/followme/userserver/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.followme.userserver.config;
+
+import com.followme.userserver.application.resolver.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -2,6 +2,7 @@ package com.followme.userserver.domain.entity;
 
 
 import com.followMe.common.entity.BaseAudit;
+import com.followme.userserver.application.dto.UserUpdateRequestDto;
 import com.followme.userserver.domain.enums.UserRole;
 import com.followme.userserver.domain.enums.UserStatus;
 import jakarta.persistence.*;
@@ -61,6 +62,21 @@ public class User extends BaseAudit {
     public void deleteUser(String deletedByUserId) {
         this.status = UserStatus.DELETED;
         super.softDelete(deletedByUserId); 
+    }
+
+    public void updateProfile(UserUpdateRequestDto request) {
+        if (request.getName() != null) {
+            this.name = request.getName();
+        }
+        if (request.getAddress() != null) {
+            this.address = request.getAddress();
+        }
+        if (request.getPhone() != null) {
+            this.phone = request.getPhone();
+        }
+        if (request.getSlackId() != null) {
+            this.slackId = request.getSlackId();
+        }
     }
 
 }

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -21,8 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("status != 'DELETED'")
 public class User extends BaseAudit {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "user_id", updatable = false, nullable = false)
+    @Column(name = "user_id", nullable = false,columnDefinition = "BINARY(16)")
     private UUID id;
 
     @Column(nullable = false, unique = true, length = 10)
@@ -54,6 +53,12 @@ public class User extends BaseAudit {
     @Column(name = "vendor_id")
     private UUID vendorId;
 
+
+    
+    public void setId(UUID id) {
+        this.id = id;
+    }
+    
     public void approve() {
         this.status = UserStatus.APPROVED;
     }
@@ -82,8 +87,10 @@ public class User extends BaseAudit {
         }
     }
 
-    public void deactivateAccount() {
+    public void deactivateAccount(String deleterUsername) {
         this.status = UserStatus.DELETED;
+
+        this.softDelete(deleterUsername);
     }
 
 }

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -11,7 +11,7 @@ import lombok.*;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_users")
+@Table(name = "p_user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -25,9 +25,6 @@ public class User extends BaseAudit {
     @Column(nullable = false, unique = true, length = 10)
     private String username;
 
-    @Column(nullable = false, length = 100)
-    private String password;
-
     @Column(nullable = false, length = 50)
     private String name;
 

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -1,8 +1,8 @@
 package com.followme.userserver.domain.entity;
 
 
-import com.followMe.common.entity.BaseAudit; 
-
+import com.followMe.common.entity.BaseAudit;
+import com.followme.userserver.application.dto.UserRegisterRequestDto;
 import com.followme.userserver.domain.enums.UserRole;
 import com.followme.userserver.domain.enums.UserStatus;
 import jakarta.persistence.*;
@@ -62,5 +62,19 @@ public class User extends BaseAudit {
     public void deleteUser(String deletedByUserId) {
         this.status = UserStatus.DELETED;
         super.softDelete(deletedByUserId); 
+    }
+
+    public static User create(UserRegisterRequestDto request) {
+        return User.builder()
+                .username(request.getUsername())
+                .name(request.getName())
+                .address(request.getAddress())
+                .phone(request.getPhone())
+                .slackId(request.getSlackId())
+                .role(request.getRole())
+                .status(UserStatus.PENDING) 
+                .hubId(request.getHubId())
+                .vendorId(request.getVendorId())
+                .build();
     }
 }

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -2,7 +2,6 @@ package com.followme.userserver.domain.entity;
 
 
 import com.followMe.common.entity.BaseAudit;
-import com.followme.userserver.application.dto.UserRegisterRequestDto;
 import com.followme.userserver.domain.enums.UserRole;
 import com.followme.userserver.domain.enums.UserStatus;
 import jakarta.persistence.*;

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -64,17 +64,4 @@ public class User extends BaseAudit {
         super.softDelete(deletedByUserId); 
     }
 
-    public static User create(UserRegisterRequestDto request) {
-        return User.builder()
-                .username(request.getUsername())
-                .name(request.getName())
-                .address(request.getAddress())
-                .phone(request.getPhone())
-                .slackId(request.getSlackId())
-                .role(request.getRole())
-                .status(UserStatus.PENDING) 
-                .hubId(request.getHubId())
-                .vendorId(request.getVendorId())
-                .build();
-    }
 }

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -10,12 +10,15 @@ import lombok.*;
 
 import java.util.UUID;
 
+import org.hibernate.annotations.SQLRestriction;
+
 @Entity
 @Table(name = "p_user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLRestriction("status != 'DELETED'")
 public class User extends BaseAudit {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -77,6 +80,10 @@ public class User extends BaseAudit {
         if (request.getSlackId() != null) {
             this.slackId = request.getSlackId();
         }
+    }
+
+    public void deactivateAccount() {
+        this.status = UserStatus.DELETED;
     }
 
 }

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -11,6 +11,7 @@ import lombok.*;
 import java.util.UUID;
 
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.domain.Persistable;
 
 @Entity
 @Table(name = "p_user")
@@ -19,9 +20,10 @@ import org.hibernate.annotations.SQLRestriction;
 @AllArgsConstructor
 @Builder
 @SQLRestriction("status != 'DELETED'")
-public class User extends BaseAudit {
+public class User extends BaseAudit implements Persistable<UUID> {
+
     @Id
-    @Column(name = "user_id", nullable = false,columnDefinition = "BINARY(16)")
+    @Column(name = "user_id", nullable = false)
     private UUID id;
 
     @Column(nullable = false, unique = true, length = 10)
@@ -53,6 +55,20 @@ public class User extends BaseAudit {
     @Column(name = "vendor_id")
     private UUID vendorId;
 
+    @Transient
+    @Builder.Default
+    private boolean isNew = true;
+
+    @Override
+    public boolean isNew() {
+        return this.isNew;
+    }
+
+    @PostPersist
+    @PostLoad
+    protected void markNotNew() {
+        this.isNew = false;
+    }
 
     
     public void setId(UUID id) {
@@ -87,7 +103,7 @@ public class User extends BaseAudit {
         }
     }
 
-    public void deactivateAccount(String deleterUsername) {
+    public void deactivateAccount(UUID deleterUsername) {
         this.status = UserStatus.DELETED;
 
         this.softDelete(deleterUsername);

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -1,0 +1,69 @@
+package com.followme.userserver.domain.entity;
+
+
+import com.followMe.common.entity.BaseAudit; 
+
+import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.enums.UserStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 10)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 255)
+    private String address;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(name = "slack_id", nullable = false, length = 50)
+    private String slackId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
+    @Column(name = "hub_id")
+    private UUID hubId;
+
+    @Column(name = "vendor_id")
+    private UUID vendorId;
+
+    public void approve() {
+        this.status = UserStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = UserStatus.REJECTED;
+    }
+
+    public void deleteUser(String deletedByUserId) {
+        this.status = UserStatus.DELETED;
+        super.softDelete(deletedByUserId); 
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -67,7 +67,7 @@ public class User extends BaseAudit {
         this.status = UserStatus.REJECTED;
     }
 
-    public void deleteUser(String deletedByUserId) {
+    public void deleteUser(UUID deletedByUserId) {
         this.status = UserStatus.DELETED;
         super.softDelete(deletedByUserId); 
     }

--- a/src/main/java/com/followme/userserver/domain/enums/UserRole.java
+++ b/src/main/java/com/followme/userserver/domain/enums/UserRole.java
@@ -1,0 +1,8 @@
+package com.followme.userserver.domain.enums;
+
+public enum UserRole {
+    MASTER,     // 마스터 관리자
+    HUB,        // 허브 관리자
+    DELIVERY,   // 배송 담당자
+    VENDOR      // 업체 담당자
+}

--- a/src/main/java/com/followme/userserver/domain/enums/UserStatus.java
+++ b/src/main/java/com/followme/userserver/domain/enums/UserStatus.java
@@ -1,0 +1,8 @@
+package com.followme.userserver.domain.enums;
+
+public enum UserStatus {
+    PENDING,    // 승인 대기 (가입 시 기본값)
+    APPROVED,   // 승인 완료
+    REJECTED,   // 승인 거절
+    DELETED     // 탈퇴/삭제
+}

--- a/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
+++ b/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.followme.userserver.domain.repository;
+
+import com.followme.userserver.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    
+    boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/followme/userserver/exception/DuplicateUsernameException.java
+++ b/src/main/java/com/followme/userserver/exception/DuplicateUsernameException.java
@@ -1,0 +1,9 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class DuplicateUsernameException extends BusinessException {
+    public DuplicateUsernameException() {
+        super(UserErrorCode.DUPLICATE_USERNAME);
+    }
+}

--- a/src/main/java/com/followme/userserver/exception/InvalidPasswordException.java
+++ b/src/main/java/com/followme/userserver/exception/InvalidPasswordException.java
@@ -1,0 +1,9 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class InvalidPasswordException extends BusinessException {
+    public InvalidPasswordException() {
+        super(UserErrorCode.INVALID_PASSWORD);
+    }
+}

--- a/src/main/java/com/followme/userserver/exception/KeycloakSyncException.java
+++ b/src/main/java/com/followme/userserver/exception/KeycloakSyncException.java
@@ -1,0 +1,9 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class KeycloakSyncException extends BusinessException {
+    public KeycloakSyncException() {
+        super(UserErrorCode.KEYCLOAK_SYNC_FAILED);
+    }
+}

--- a/src/main/java/com/followme/userserver/exception/UserErrorCode.java
+++ b/src/main/java/com/followme/userserver/exception/UserErrorCode.java
@@ -1,0 +1,20 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    
+    // User 서비스만의 고유 에러 코드
+    DUPLICATE_USERNAME("U001", "이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT), // 409 Conflict
+    USER_NOT_FOUND("U002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),     // 404 Not Found
+    INVALID_PASSWORD("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED); // 401 Unauthorized
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/followme/userserver/exception/UserErrorCode.java
+++ b/src/main/java/com/followme/userserver/exception/UserErrorCode.java
@@ -12,7 +12,8 @@ public enum UserErrorCode implements ErrorCode {
     // User 서비스만의 고유 에러 코드
     DUPLICATE_USERNAME("U001", "이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT), // 409 Conflict
     USER_NOT_FOUND("U002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),     // 404 Not Found
-    INVALID_PASSWORD("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED); // 401 Unauthorized
+    INVALID_PASSWORD("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED), // 401 Unauthorized
+    KEYCLOAK_SYNC_FAILED("U004", "인증 서버에 유저를 생성하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR); // 500 Internal Server Error
 
     private final String code;
     private final String message;

--- a/src/main/java/com/followme/userserver/exception/UserNotFoundException.java
+++ b/src/main/java/com/followme/userserver/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+    public UserNotFoundException() {
+        super(UserErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -9,6 +9,7 @@ import com.followme.userserver.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,4 +49,13 @@ public class UserController {
         
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse> deactivateMyAccount(@CurrentUser String username) {
+        
+        userService.deactivateMyAccount(username);
+        
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+    
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -4,11 +4,13 @@ import com.followMe.common.response.ApiResponse;
 import com.followme.userserver.application.annotation.CurrentUser;
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
 import com.followme.userserver.application.dto.UserResponseDto;
+import com.followme.userserver.application.dto.UserUpdateRequestDto;
 import com.followme.userserver.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,16 @@ public class UserController {
     public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser String username) {
         
         UserResponseDto responseDto = userService.getUserProfile(username);
+        
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse> updateMyProfile(
+            @CurrentUser String username,
+            @RequestBody UserUpdateRequestDto request) {
+
+        UserResponseDto responseDto = userService.updateUserProfile(username, request);
         
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -3,6 +3,7 @@ package com.followme.userserver.presentation.controller;
 import com.followMe.common.response.ApiResponse;
 import com.followme.userserver.application.annotation.CurrentUser;
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.application.dto.UserResponseDto;
 import com.followme.userserver.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +29,11 @@ public class UserController {
         return ApiResponse.created();
     }
 
-    @GetMapping("/me-test")
-    public ResponseEntity<ApiResponse> testCurrentUser(@CurrentUser String username) {
-        // 토큰에서 뽑아온 username을 그대로 응답 데이터(data)로 내려보내 봅니다.
-        return ResponseEntity.ok(ApiResponse.success(username));
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser String username) {
+        
+        UserResponseDto responseDto = userService.getUserProfile(username);
+        
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.followme.userserver.presentation.controller;
+
+import com.followMe.common.response.ApiResponse;
+import com.followme.userserver.application.dto.UserRegisterRequestDto;
+import com.followme.userserver.application.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody UserRegisterRequestDto request) {
+        
+        userService.registerUser(request);
+
+        return ApiResponse.created();
+    }
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -1,11 +1,13 @@
 package com.followme.userserver.presentation.controller;
 
 import com.followMe.common.response.ApiResponse;
+import com.followme.userserver.application.annotation.CurrentUser;
 import com.followme.userserver.application.dto.UserRegisterRequestDto;
 import com.followme.userserver.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +26,11 @@ public class UserController {
         userService.registerUser(request);
 
         return ApiResponse.created();
+    }
+
+    @GetMapping("/me-test")
+    public ResponseEntity<ApiResponse> testCurrentUser(@CurrentUser String username) {
+        // 토큰에서 뽑아온 username을 그대로 응답 데이터(data)로 내려보내 봅니다.
+        return ResponseEntity.ok(ApiResponse.success(username));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,4 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          # 여기를 9090으로 변경했습니다!
           issuer-uri: http://localhost:9090/realms/user

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,12 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:9090/realms/user
+
+keycloak:
+  server-url: http://localhost:9090
+  realm: user
+  admin:
+    realm: master
+    client-id: admin-cli
+    username: admin
+    password: admin


### PR DESCRIPTION
📌 관련 이슈
close #5

💡 작업 내용
내 프로필 조회(GET /me), 수정(PATCH /me), 비활성화(DELETE /me) API 구현

정보 수정 및 탈퇴 엔드포인트를 /{userId}에서 /me로 변경하여 본인 인증 구조 단순화

Keycloak 발급 UUID와 로컬 DB PK를 동기화하여 식별자 파편화 해결

Soft Delete 처리 시 deleted_at 및 deleted_by(토큰의 UUID)가 기록되도록 감사(Audit) 로직 적용


🔍 변경 이유
사용자가 안전하게 본인의 정보를 관리할 수 있는 마이페이지 핵심 기능 제공

/me 엔드포인트 활용을 통해 타인 정보 접근을 원천 차단하고 불필요한 권한 검증 로직 최소화


🧠 기타 참고 사항
Postman 테스트 완료: API 정상 응답 및 DB 상태값(DELETED) 변경, Keycloak 유저 비활성화(Enabled: false) 정상 작동 확인