### PR TITLE
[REFACTOR] SecurityConfig 내 JWT 검증 로직 제거 및 인증 구조 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
-	id 'com.diffplug.spotless' version '6.25.0' // Spotless 플러그인 추가
+	id 'com.diffplug.spotless' version '6.25.0'
 }
 
 group = 'com.followme'
@@ -32,12 +32,11 @@ repositories {
 }
 
 ext {
-    // Spring Boot 3.x 버전과 호환되는 Spring Cloud 버전입니다.
     set('springCloudVersion', "2025.0.0")
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.3' // 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.4' // 공통 라이브러리 의존성 추가
 
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres-keycloak:
-    image: postgres:18
+    image: postgres:17
     container_name: postgres-keycloak
     restart: unless-stopped
     environment:

--- a/src/main/java/com/followme/userserver/application/dto/UserResponse.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserResponse.java
@@ -34,8 +34,12 @@ public class UserResponse {
         private UUID userId;
         private String username;
         private String name;
-        private String role;
+        private String address;
+        private String phone;
         private String slackId;
+        private UserRole role;
+        private UserStatus status;
         private UUID hubId;
+        private UUID vendorId;
     }
 }

--- a/src/main/java/com/followme/userserver/application/dto/UserResponse.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserResponse.java
@@ -41,5 +41,7 @@ public class UserResponse {
         private UserStatus status;
         private UUID hubId;
         private UUID vendorId;
+        private Long sequence;
     }
+    
 }

--- a/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/followme/userserver/application/resolver/CurrentUserArgumentResolver.java
@@ -7,23 +7,25 @@ import com.followme.userserver.application.annotation.CurrentUser;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.util.UUID;
+
 @Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     // Resolver가 언제 동작할지 결정
-    // 파라미터에 @CurrentUser 가 붙어있고, 타입이 String(username)일 때 동작
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean hasAnnotation = parameter.hasParameterAnnotation(CurrentUser.class);
-        boolean isStringType = String.class.isAssignableFrom(parameter.getParameterType());
-        return hasAnnotation && isStringType;
+
+        boolean isUuidType = UUID.class.isAssignableFrom(parameter.getParameterType());
+        
+        return hasAnnotation && isUuidType;
     }
 
     @Override
@@ -32,19 +34,15 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        // 인증 정보가 없거나, 익명 사용자면 Exception 반환
-        if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
+
+        if (authentication == null || !authentication.isAuthenticated() || "anonymousUser".equals(authentication.getPrincipal())) {
             throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
         }
-
-        // Keycloak Oauth2 리소스 서버를 쓰면 Principal이 Jwt 객체로 들어옵니다.
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof Jwt jwt) {
-            // Keycloak이 발급한 토큰의 "preferred_username"을 꺼냅니다.
-            return jwt.getClaimAsString("preferred_username"); 
-        }
         
-
-        return authentication.getName();
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/InternalUserQueryService.java
+++ b/src/main/java/com/followme/userserver/application/service/InternalUserQueryService.java
@@ -50,4 +50,22 @@ public class InternalUserQueryService {
                 .map(userMapper::toInternalResponseDto)
                 .toList();
     }
+    
+    @Transactional(readOnly = true)
+    public List<UserResponse.Internal> getDeliveryManagers(UUID nodeId, String type) {
+        List<User> deliveryUsers;
+
+        if ("HUB".equalsIgnoreCase(type)) {
+            deliveryUsers = userRepository.findAllByHubIdAndRoleOrderBySequenceAsc(nodeId, UserRole.DELIVERY);
+        } else if ("VENDOR".equalsIgnoreCase(type)) {
+            deliveryUsers = userRepository.findAllByVendorIdAndRoleOrderBySequenceAsc(nodeId, UserRole.DELIVERY);
+        } else {
+            throw new IllegalArgumentException("Unsupported NodeType: " + type);
+        }
+
+        return deliveryUsers.stream()
+                .map(userMapper::toInternalResponseDto)
+                .toList();
+    }
+    
 }

--- a/src/main/java/com/followme/userserver/application/service/UserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserCommandService.java
@@ -7,9 +7,11 @@ import com.followme.userserver.application.dto.UserResponse;
 import com.followme.userserver.application.mapper.UserMapper;
 import com.followme.userserver.application.port.AuthPort;
 import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserRole;
 import com.followme.userserver.domain.enums.UserStatus;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.DuplicateUsernameException;
+import com.followme.userserver.exception.InvalidDeliveryAssociationException;
 import com.followme.userserver.exception.KeycloakSyncException;
 import com.followme.userserver.exception.UserNotFoundException;
 
@@ -43,6 +45,16 @@ public class UserCommandService {
         if (userRepository.existsByUsername(request.getUsername())) {
             throw new DuplicateUsernameException();
         }
+
+        if (request.getRole() == UserRole.DELIVERY) {
+            boolean hasHub = request.getHubId() != null;
+            boolean hasVendor = request.getVendorId() != null;
+
+            if ((!hasHub && !hasVendor) || (hasHub && hasVendor)) {
+                throw new InvalidDeliveryAssociationException();
+            }
+        }
+
 
         UserRepresentation kcUser = new UserRepresentation();
         kcUser.setUsername(request.getUsername());
@@ -107,13 +119,35 @@ public class UserCommandService {
             user.approve();
             authPort.syncKeycloakUserStatus(userId, true);
             authPort.assignRealmRole(userId, user.getRole().name());
+
+            // [Added] Sequence allocation for delivery drivers upon approval
+            if (user.getRole() == UserRole.DELIVERY) {
+                Long currentMaxSequence = 0L;
+                
+                // Determine the correct queue based on association
+                if (user.getHubId() != null) {
+                    currentMaxSequence = userRepository.findMaxSequenceByHubIdAndRole(user.getHubId(), UserRole.DELIVERY);
+                } else if (user.getVendorId() != null) {
+                    currentMaxSequence = userRepository.findMaxSequenceByVendorIdAndRole(user.getVendorId(), UserRole.DELIVERY);
+                }
+                
+                // Assign the next available sequence (back of the line)
+                user.updateSequence(currentMaxSequence + 1);
+            }
+
         } else if (request.getStatus() == UserStatus.REJECTED) {
             user.reject();
             authPort.syncKeycloakUserStatus(userId, false);
+            
+            // [Added] Ensure sequence is cleared if a user is rejected
+            user.updateSequence(null);
+
         } else {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT);
         }
 
         return userMapper.toResponseDto(user);
     }
+
+    
 }

--- a/src/main/java/com/followme/userserver/application/service/UserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserCommandService.java
@@ -12,7 +12,6 @@ import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.DuplicateUsernameException;
 import com.followme.userserver.exception.KeycloakSyncException;
 import com.followme.userserver.exception.UserNotFoundException;
-import com.followme.userserver.infrastructure.keycloak.KeycloakAdapter;
 
 import jakarta.ws.rs.core.Response;
 import lombok.RequiredArgsConstructor;
@@ -75,31 +74,25 @@ public class UserCommandService {
     }
 
     @Transactional
-    public UserResponse.Info updateUserProfile(String username, UserRequest.UpdateProfile request) {
-        User user = userRepository.findByUsername(username)
+    public UserResponse.Info updateUserProfile(UUID userId, UserRequest.UpdateProfile request) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         user.updateProfile(request);
         return userMapper.toResponseDto(user);
     }
 
     @Transactional
-    public void deactivateMyAccount(String username) {
-        User user = userRepository.findByUsername(username)
+    public void deactivateMyAccount(UUID userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
         String currentTokenUserId = SecurityContextHolder.getContext().getAuthentication().getName();
         user.deactivateAccount(UUID.fromString(currentTokenUserId));
         
         try {
-            List<UserRepresentation> kcUsers = keycloak.realm(realm).users().search(username);
-            
-            if (kcUsers != null && !kcUsers.isEmpty()) {
-                UserRepresentation kcUser = kcUsers.get(0); 
-                kcUser.setEnabled(false); 
-                keycloak.realm(realm).users().get(kcUser.getId()).update(kcUser);
-            } else {
-                throw new KeycloakSyncException(); 
-            }
+            UserRepresentation kcUser = keycloak.realm(realm).users().get(userId.toString()).toRepresentation();
+            kcUser.setEnabled(false);
+            keycloak.realm(realm).users().get(userId.toString()).update(kcUser);
         } catch (Exception e) {
             throw new KeycloakSyncException(); 
         }

--- a/src/main/java/com/followme/userserver/application/service/UserQueryService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserQueryService.java
@@ -17,26 +17,24 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserQueryService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;
 
-    @Transactional(readOnly = true)
     public UserResponse.Info getUserProfile(UUID userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         return userMapper.toResponseDto(user);
     }
 
-    @Transactional(readOnly = true)
     public UserResponse.Info getUserById(UUID userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         return userMapper.toResponseDto(user);
     }
 
-    @Transactional(readOnly = true)
     public PageResponse<UserResponse.Info> getAllUsers(Pageable pageable) {
         Page<User> userPage = userRepository.findAll(pageable);
         return PageResponse.of(userPage, userMapper::toResponseDto);

--- a/src/main/java/com/followme/userserver/application/service/UserQueryService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserQueryService.java
@@ -23,8 +23,8 @@ public class UserQueryService {
     private final UserMapper userMapper;
 
     @Transactional(readOnly = true)
-    public UserResponse.Info getUserProfile(String username) {
-        User user = userRepository.findByUsername(username)
+    public UserResponse.Info getUserProfile(UUID userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
         return userMapper.toResponseDto(user);
     }

--- a/src/main/java/com/followme/userserver/config/SecurityConfig.java
+++ b/src/main/java/com/followme/userserver/config/SecurityConfig.java
@@ -2,27 +2,23 @@ package com.followme.userserver.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import com.followme.userserver.infrastructure.security.UserContextFilter;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final UserContextFilter userContextFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -49,48 +45,18 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/users/me").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/users/me").authenticated()
 
-                // [그룹 4] Admin: MASTER 권한 전용 사용자 관리 (명세서 순서대로 나열)
+                // [그룹 4] Admin: MASTER 권한 전용 사용자 관리
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/users/*/status").hasRole("MASTER") // 승인/거절 처리
                 .requestMatchers(HttpMethod.GET, "/api/v1/users").hasRole("MASTER")            // 전체 사용자 목록 검색
                 .requestMatchers(HttpMethod.GET, "/api/v1/users/*").hasRole("MASTER")          // 특정 사용자 상세 조회
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/users/*").hasRole("MASTER")        // 사용자 정보 수정
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/users/*").hasRole("MASTER")       // 사용자 계정 비활성화
 
-                // [그 외] 혹시 빼먹은 요청이 있다면 무조건 인증을 요구하여 1차 방어
                 .anyRequest().authenticated()
             )
             
-            // 🌟 4. [핵심 변경 사항] 기본 설정 대신 Keycloak 전용 토큰 번역기를 달아줍니다!
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> 
-                jwt.jwtAuthenticationConverter(keycloakJwtConverter())
-            ));
+            .addFilterBefore(userContextFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
-    }
-
-    /**
-     * 💡 Keycloak 토큰의 realm_access -> roles 안에 있는 권한을 꺼내서
-     * 스프링 시큐리티가 알아먹을 수 있는 "ROLE_MASTER" 형태로 번역해 주는 메서드
-     */
-    private Converter<Jwt, AbstractAuthenticationToken> keycloakJwtConverter() {
-        return jwt -> {
-            // 1. 스프링의 기본 권한 추출기 동작 (scope 등 추출)
-            JwtGrantedAuthoritiesConverter defaultConverter = new JwtGrantedAuthoritiesConverter();
-            Collection<GrantedAuthority> authorities = new ArrayList<>(defaultConverter.convert(jwt));
-            
-            // 2. Keycloak 전용 데이터(realm_access) 파싱
-            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
-            if (realmAccess != null && realmAccess.containsKey("roles")) {
-                List<String> roles = (List<String>) realmAccess.get("roles");
-                
-                // 3. 추출한 "MASTER" 앞에 "ROLE_"을 붙여서 스프링 시큐리티에 등록
-                for (String role : roles) {
-                    authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
-                }
-            }
-            
-            // 4. 완성된 권한 목록을 스프링 시큐리티 컨텍스트에 전달
-            return new JwtAuthenticationToken(jwt, authorities);
-        };
     }
 }

--- a/src/main/java/com/followme/userserver/config/SecurityConfig.java
+++ b/src/main/java/com/followme/userserver/config/SecurityConfig.java
@@ -34,8 +34,11 @@ public class SecurityConfig {
 
                 .requestMatchers("/error").permitAll() // Spring Boot 기본 에러 페이지는 인증 없이 접근 가능하도록 허용
                 
-                // [그룹 1] Public: 로그인 없이 접근 가능
+                // [그룹 1] Public: 로그인 없이 접근 가능 (Gateway와 맞게 연동)
+                .requestMatchers("/api/v1/auth/**", "/api/v1/public/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/users/register").permitAll()
+
+                .requestMatchers("/register").permitAll() // 회원가입 페이지는 인증 없이 접근 가능하도록 허용
 
                 // [그룹 2] Internal: 다른 마이크로서비스 서버 간 내부 호출용
                 .requestMatchers("/internal/v1/users/**").permitAll()

--- a/src/main/java/com/followme/userserver/domain/entity/User.java
+++ b/src/main/java/com/followme/userserver/domain/entity/User.java
@@ -55,6 +55,9 @@ public class User extends BaseAudit implements Persistable<UUID> {
     @Column(name = "vendor_id")
     private UUID vendorId;
 
+    @Column(name = "sequence")
+    private Long sequence;
+
     @Transient
     @Builder.Default
     private boolean isNew = true;
@@ -107,6 +110,10 @@ public class User extends BaseAudit implements Persistable<UUID> {
         this.status = UserStatus.DELETED;
 
         this.softDelete(deleterUsername);
+    }
+
+    public void updateSequence(Long newSequence) {
+        this.sequence = newSequence;
     }
 
 }

--- a/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
+++ b/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
@@ -4,6 +4,8 @@ import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserRole;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +18,13 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByUsername(String username);
 
     List<User> findAllByHubIdAndRole(UUID hubId, UserRole role);
+
+    List<User> findAllByHubIdAndRoleOrderBySequenceAsc(UUID hubId, UserRole role);
+    List<User> findAllByVendorIdAndRoleOrderBySequenceAsc(UUID vendorId, UserRole role);
+
+    @Query("SELECT COALESCE(MAX(u.sequence), 0L) FROM User u WHERE u.hubId = :hubId AND u.role = :role")
+    Long findMaxSequenceByHubIdAndRole(@Param("hubId") UUID hubId, @Param("role") UserRole role);
+
+    @Query("SELECT COALESCE(MAX(u.sequence), 0L) FROM User u WHERE u.vendorId = :vendorId AND u.role = :role")
+    Long findMaxSequenceByVendorIdAndRole(@Param("vendorId") UUID vendorId, @Param("role") UserRole role);
 }

--- a/src/main/java/com/followme/userserver/exception/InvalidDeliveryAssociationException.java
+++ b/src/main/java/com/followme/userserver/exception/InvalidDeliveryAssociationException.java
@@ -1,0 +1,10 @@
+package com.followme.userserver.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class InvalidDeliveryAssociationException extends BusinessException {
+    
+    public InvalidDeliveryAssociationException() {
+        super(UserErrorCode.INVALID_DELIVERY_ASSOCIATION);
+    }
+}

--- a/src/main/java/com/followme/userserver/exception/UserErrorCode.java
+++ b/src/main/java/com/followme/userserver/exception/UserErrorCode.java
@@ -13,7 +13,9 @@ public enum UserErrorCode implements ErrorCode {
     DUPLICATE_USERNAME("U001", "이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT), // 409 Conflict
     USER_NOT_FOUND("U002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),     // 404 Not Found
     INVALID_PASSWORD("U003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED), // 401 Unauthorized
-    KEYCLOAK_SYNC_FAILED("U004", "인증 서버에 유저를 생성하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR); // 500 Internal Server Error
+    KEYCLOAK_SYNC_FAILED("U004", "인증 서버에 유저를 생성하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR), // 500 Internal Server Error
+
+    INVALID_DELIVERY_ASSOCIATION("U005", "배송 기사는 허브 또는 업체 중 단 하나의 소속만 지정되어야 합니다.", HttpStatus.BAD_REQUEST); // 400 Bad Request
 
     private final String code;
     private final String message;

--- a/src/main/java/com/followme/userserver/infrastructure/security/UserContextFilter.java
+++ b/src/main/java/com/followme/userserver/infrastructure/security/UserContextFilter.java
@@ -1,0 +1,47 @@
+package com.followme.userserver.infrastructure.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Slf4j
+@Component
+public class UserContextFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-Role");
+
+        if (StringUtils.hasText(userId) && StringUtils.hasText(role)) {
+            try {
+                SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + role.toUpperCase());
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userId, "", Collections.singletonList(authority));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                
+                log.debug("User Context 설정 완료 - UserID: {}, Role: {}", userId, role);
+            } catch (Exception e) {
+                log.error("User Context 설정 중 오류 발생", e);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/InternalUserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/InternalUserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.followMe.common.response.ApiResponse;
@@ -47,6 +48,16 @@ public class InternalUserController {
     @GetMapping("/hub/{hubId}/managers")
     public ResponseEntity<ApiResponse> getManagersByHub(@PathVariable UUID hubId) {
         List<UserResponse.Internal> responseList = internalUserQueryService.getManagersByHub(hubId);
+        return ApiResponse.ok(responseList);
+    }
+
+    @GetMapping("/deliveries")
+    public ResponseEntity<ApiResponse> getDeliveryManagers(
+            @RequestParam("hubId") UUID hubId, // 명세서 스펙 상 이름은 hubId지만 vendorId 역할도 겸함
+            @RequestParam("type") String type) {
+        
+        List<UserResponse.Internal> responseList = internalUserQueryService.getDeliveryManagers(hubId, type);
+        
         return ApiResponse.ok(responseList);
     }
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -100,20 +100,4 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 
-    @GetMapping("/me/test")
-    public ResponseEntity<String> getMyInfoTest(
-            Principal principal, 
-            Authentication authentication) {
-        
-        // 1. User-Id 꺼내기 (필터에서 첫 번째 파라미터로 넣었던 값)
-        String userId = principal.getName();
-        
-        // 2. X-Role 꺼내기 (필터에서 Authority로 넣었던 값)
-        String role = authentication.getAuthorities().toString();
-
-        // 3. 화면에 잘 나오는지 조합해서 응답해보기
-        String result = String.format("🎉 인증 성공! \n내 아이디(UUID): %s \n내 권한(Role): %s", userId, role);
-        
-        return ResponseEntity.ok(result);
-    }
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -11,10 +11,12 @@ import com.followme.userserver.application.service.UserQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.security.Principal;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -42,27 +44,27 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser String username) {
+    public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser UUID userId) {
         
-        UserResponse.Info responseDto = userQueryService.getUserProfile(username);
+        UserResponse.Info responseDto = userQueryService.getUserProfile(userId);
         
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse> updateMyProfile(
-            @CurrentUser String username,
+            @CurrentUser UUID userId,
             @RequestBody UserRequest.UpdateProfile request) {
 
-        UserResponse.Info responseDto = userCommandService.updateUserProfile(username, request);
+        UserResponse.Info responseDto = userCommandService.updateUserProfile(userId, request);
         
         return ResponseEntity.ok(ApiResponse.success(responseDto));
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse> deactivateMyAccount(@CurrentUser String username) {
+    public ResponseEntity<ApiResponse> deactivateMyAccount(@CurrentUser UUID userId) {
         
-        userCommandService.deactivateMyAccount(username);
+        userCommandService.deactivateMyAccount(userId);
         
         return ResponseEntity.ok(ApiResponse.success(null));
     }
@@ -96,5 +98,22 @@ public class UserController {
         PageResponse<UserResponse.Info> responseDto = userQueryService.getAllUsers(pageable);
 
         return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
+
+    @GetMapping("/me/test")
+    public ResponseEntity<String> getMyInfoTest(
+            Principal principal, 
+            Authentication authentication) {
+        
+        // 1. User-Id 꺼내기 (필터에서 첫 번째 파라미터로 넣었던 값)
+        String userId = principal.getName();
+        
+        // 2. X-Role 꺼내기 (필터에서 Authority로 넣었던 값)
+        String role = authentication.getAuthorities().toString();
+
+        // 3. 화면에 잘 나오는지 조합해서 응답해보기
+        String result = String.format("🎉 인증 성공! \n내 아이디(UUID): %s \n내 권한(Role): %s", userId, role);
+        
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,8 @@ spring:
         jwt:
           issuer-uri: http://localhost:9090/realms/user
 
+  jackson:
+    default-property-inclusion: non_null
 keycloak:
   server-url: http://localhost:9090
   realm: user


### PR DESCRIPTION
📌 관련 이슈
close #19 

💡 작업 내용
-JWT 설정 제거: 기존 oauth2ResourceServer 및 keycloakJwtConverter 관련 로직 완전 삭제

-인증 흐름 단일화: API Gateway가 전달하는 X- 헤더 기반의 UserContextFilter만 사용하도록 보안 체계 수정


🔍 변경 이유
-MSA 아키텍처 원칙에 따라 내부 마이크로서비스의 중복된 토큰 검증 부하를 줄이고, 게이트웨이의 인증 결과를 전적으로 신뢰하기 위함


🧠 기타 참고 사항
-이제 포스트맨 테스트 시 JWT(Bearer Token) 없이 헤더(X-User-Id, X-Role)만으로 인증 통과가 가능합니다.