### PR TITLE
[FEAT] Zipkin 분산 추적 인프라 구축 및 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ ext {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.4' // 공통 라이브러리 의존성 추가
+	// 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.4' 
 
-	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
+	// Keycloak Admin Client 의존성 추가
+	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
 
 	// MapStruct 핵심 라이브러리
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
@@ -46,6 +48,15 @@ dependencies {
     
     // Lombok과의 공존을 위한 바인딩 (필수)
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+	// 모니터링 및 메트릭 수집 (필수)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // 분산 추적 - Micrometer Tracing (Brave 브릿지 사용)
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    
+    // Zipkin으로 트레이스 데이터를 전송하는 리포터
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,19 @@ services:
     networks:
       - keycloak-net
 
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin-server
+    restart: unless-stopped
+    ports:
+      - '9411:9411'
+    networks:
+      - keycloak-net
+
 volumes:
   postgres-keycloak-data:
   keycloak-data:
 
 networks:
   keycloak-net:
+  

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
 
   jackson:
     default-property-inclusion: non_null
+
 keycloak:
   server-url: http://localhost:9090
   realm: user
@@ -36,3 +37,15 @@ keycloak:
     client-id: admin-cli
     username: admin
     password: admin
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  tracing:
+    sampling:
+      probability: 1.0 # 1.0은 100% 기록 (운영 환경에서는 부하를 위해 0.1(10%) 등으로 낮춤)
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"


### PR DESCRIPTION
### 📌 관련 이슈
- close #27 

### 💡 작업 내용
- Micrometer Tracing 및 Zipkin Reporter 의존성 추가
- Docker Compose 내 Zipkin 서버 인프라 구축

### 🔍 변경 이유
- 서비스 간 요청 흐름 시각화 및 지연 구간 식별

### 🧠 기타 참고 사항
- 로컬 환경 테스트를 통한 대시보드 연동 정상 확인 완료