### PR TITLE
[FEAT] Swagger API 문서 자동화 및 통합 #29

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ ext {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.4' // 공통 라이브러리 의존성 추가
+	// 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.4' 
 
-	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
+	// Keycloak Admin Client 의존성 추가
+	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
 
 	// MapStruct 핵심 라이브러리
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
@@ -46,6 +48,15 @@ dependencies {
     
     // Lombok과의 공존을 위한 바인딩 (필수)
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+	// 모니터링 및 메트릭 수집 (필수)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // 분산 추적 - Micrometer Tracing (Brave 브릿지 사용)
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    
+    // Zipkin으로 트레이스 데이터를 전송하는 리포터
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
 
 dependencies {
 	// 공통 라이브러리 의존성 추가
-	implementation 'com.followMe:common-lib:1.0.4' 
+	implementation 'com.followMe:common-lib:1.0.7' 
 
 	// Keycloak Admin Client 의존성 추가
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
@@ -57,6 +57,9 @@ dependencies {
     
     // Zipkin으로 트레이스 데이터를 전송하는 리포터
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
+	// OpenAPI 문서화 도구
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,19 @@ services:
     networks:
       - keycloak-net
 
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin-server
+    restart: unless-stopped
+    ports:
+      - '9411:9411'
+    networks:
+      - keycloak-net
+
 volumes:
   postgres-keycloak-data:
   keycloak-data:
 
 networks:
   keycloak-net:
+  

--- a/src/main/java/com/followme/userserver/config/OpenApiConfig.java
+++ b/src/main/java/com/followme/userserver/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.followme.userserver.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("User Service API")
+                .version("v1.0.0")
+                .description("사용자 및 배송 담당자 관리 API"));
+    }
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -8,6 +8,10 @@ import com.followme.userserver.application.dto.UserRequest;
 import com.followme.userserver.application.dto.UserResponse;
 import com.followme.userserver.application.service.UserCommandService;
 import com.followme.userserver.application.service.UserQueryService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -15,87 +19,66 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class UserController {
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
     @PostMapping("/register")
+    @SecurityRequirements()
     public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody UserRequest.Register request) {
-        
         userCommandService.registerUser(request);
-
         return ApiResponse.created();
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser UUID userId) {
-        
+    public ResponseEntity<ApiResponse> getMyProfile(
+            @Parameter(hidden = true) @CurrentUser UUID userId) {
         UserResponse.Info responseDto = userQueryService.getUserProfile(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse> updateMyProfile(
-            @CurrentUser UUID userId,
+            @Parameter(hidden = true) @CurrentUser UUID userId,
             @RequestBody UserRequest.UpdateProfile request) {
-
         UserResponse.Info responseDto = userCommandService.updateUserProfile(userId, request);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse> deactivateMyAccount(@CurrentUser UUID userId) {
-        
+    public ResponseEntity<ApiResponse> deactivateMyAccount(
+            @Parameter(hidden = true) @CurrentUser UUID userId) {
         userCommandService.deactivateMyAccount(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ApiResponse.ok();
     }
     
     @PatchMapping("/{userId}/status")
     public ResponseEntity<ApiResponse> updateUserStatus(
             @PathVariable UUID userId,
             @RequestBody UserRequest.UpdateStatus request) {
-        
         UserResponse.Info responseDto = userCommandService.updateUserStatus(userId, request);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse> getUserById(@PathVariable UUID userId) {
-        
         UserResponse.Info responseDto = userQueryService.getUserById(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse> getAllUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-
-        // 1. common-lib의 PageRequest를 통해 검증된 Pageable 객체 생성 (10, 30, 50 사이즈 강제)
-        Pageable pageable = PageRequest.of(page, size).toPageable();
-
+        Pageable pageable = com.followMe.common.pagination.PageRequest.of(page, size).toPageable();
         PageResponse<UserResponse.Info> responseDto = userQueryService.getAllUsers(pageable);
-
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
-
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.followme.userserver.presentation.controller;
 
-import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
 import com.followMe.common.response.ApiResponse;
 import com.followme.userserver.application.annotation.CurrentUser;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
 
   jackson:
     default-property-inclusion: non_null
+
 keycloak:
   server-url: http://localhost:9090
   realm: user
@@ -36,3 +37,15 @@ keycloak:
     client-id: admin-cli
     username: admin
     password: admin
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  tracing:
+    sampling:
+      probability: 1.0 # 1.0은 100% 기록 (운영 환경에서는 부하를 위해 0.1(10%) 등으로 낮춤)
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"


### PR DESCRIPTION
### 📌 관련 이슈
- close #29
 
### 💡 작업 내용
- `user-server` springdoc-openapi 의존성 추가
- `OpenApiConfig` 적용 및 Gateway 기반 Swagger 라우팅(Aggregation) 설정
- 외부 노출 API 대상 `@SecurityRequirement(name = "bearerAuth")` 적용

### 🔍 변경 이유
- MSA 환경에서의 분산된 API 명세서를 통합.

### 🧠 기타 참고 사항
- 아직 common-lib로 Swagger를 받지 않았음으로 이후 common-lib로 부터 받은 이후 PR 할 예정