### PR TITLE
[FEAT] Kafka 및 Outbox 패턴 인프라 연동 및 도메인 이벤트 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ ext {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.4' // 공통 라이브러리 의존성 추가
+	// 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.4' 
 
-	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
+	// Keycloak Admin Client 의존성 추가
+	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
 
 	// MapStruct 핵심 라이브러리
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
@@ -46,6 +48,15 @@ dependencies {
     
     // Lombok과의 공존을 위한 바인딩 (필수)
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+	// 모니터링 및 메트릭 수집 (필수)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // 분산 추적 - Micrometer Tracing (Brave 브릿지 사용)
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    
+    // Zipkin으로 트레이스 데이터를 전송하는 리포터
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
 
 dependencies {
 	// 공통 라이브러리 의존성 추가
-	implementation 'com.followMe:common-lib:1.0.4' 
+	implementation 'com.followMe:common-lib:1.0.7' 
 
 	// Keycloak Admin Client 의존성 추가
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
@@ -57,6 +57,9 @@ dependencies {
     
     // Zipkin으로 트레이스 데이터를 전송하는 리포터
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
+	// OpenAPI 문서화 도구
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 	// OpenAPI 문서화 도구
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
+	// Kafka & Outbox 패턴 활성화를 위한 의존성
+    implementation 'org.springframework.kafka:spring-kafka'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,9 @@ services:
     networks:
       - keycloak-net
 
-  kafka:
+  kafka-1:
     image: confluentinc/cp-kafka:7.5.0
-    container_name: kafka
+    container_name: kafka-1
     depends_on:
       - zookeeper
     ports:
@@ -65,10 +65,53 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:29092,PLAINTEXT_HOST://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    networks:
+      - keycloak-net
+
+  kafka-2:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka-2
+    depends_on:
+      - zookeeper
+    ports:
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    networks:
+      - keycloak-net
+
+  kafka-3:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka-3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:29094,PLAINTEXT_HOST://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     networks:
       - keycloak-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,38 @@ services:
       - '9411:9411'
     networks:
       - keycloak-net
+  
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - keycloak-net
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - keycloak-net
 
 volumes:
   postgres-keycloak-data:
   keycloak-data:
+  zookeeper-data:
+  kafka-data:
 
 networks:
   keycloak-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,19 @@ services:
     networks:
       - keycloak-net
 
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin-server
+    restart: unless-stopped
+    ports:
+      - '9411:9411'
+    networks:
+      - keycloak-net
+
 volumes:
   postgres-keycloak-data:
   keycloak-data:
 
 networks:
   keycloak-net:
+  

--- a/src/main/java/com/followme/userserver/application/service/InternalUserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/InternalUserCommandService.java
@@ -1,7 +1,9 @@
 package com.followme.userserver.application.service;
 
+import com.followMe.common.event.Events;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.event.DeliverySequenceUpdatedEvent;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +36,9 @@ public class InternalUserCommandService {
         }
 
         user.updateSequence(currentMaxSequence + 1);
+
+        Events.trigger(
+            new DeliverySequenceUpdatedEvent(user.getId(), user.getSequence())
+        );
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/UserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserCommandService.java
@@ -1,5 +1,6 @@
 package com.followme.userserver.application.service;
 
+import com.followMe.common.event.Events;
 import com.followMe.common.exception.BusinessException;
 import com.followMe.common.exception.CommonErrorCode;
 import com.followme.userserver.application.dto.UserRequest;
@@ -9,6 +10,9 @@ import com.followme.userserver.application.port.AuthPort;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserRole;
 import com.followme.userserver.domain.enums.UserStatus;
+import com.followme.userserver.domain.event.UserCreatedEvent;
+import com.followme.userserver.domain.event.UserDeactivatedEvent;
+import com.followme.userserver.domain.event.UserStatusUpdatedEvent;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.DuplicateUsernameException;
 import com.followme.userserver.exception.InvalidDeliveryAssociationException;
@@ -78,8 +82,12 @@ public class UserCommandService {
 
         User newUser = userMapper.toEntity(request);
         newUser.setId(UUID.fromString(keycloakUserId));
-
+        
         userRepository.save(newUser);
+
+        Events.trigger(
+            new UserCreatedEvent(newUser.getId(), newUser.getUsername(), newUser.getRole().name())
+        );
     }
 
     @Transactional
@@ -105,6 +113,27 @@ public class UserCommandService {
         } catch (Exception e) {
             throw new KeycloakSyncException(); 
         }
+
+        Events.trigger(new UserDeactivatedEvent(user.getId()));
+    }
+
+    @Transactional
+    public void deactivateAccount(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        String currentTokenUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+        user.deactivateAccount(UUID.fromString(currentTokenUserId));
+        
+        try {
+            UserRepresentation kcUser = keycloak.realm(realm).users().get(userId.toString()).toRepresentation();
+            kcUser.setEnabled(false);
+            keycloak.realm(realm).users().get(userId.toString()).update(kcUser);
+        } catch (Exception e) {
+            throw new KeycloakSyncException(); 
+        }
+
+        Events.trigger(new UserDeactivatedEvent(user.getId()));
     }
 
     @Transactional
@@ -141,6 +170,10 @@ public class UserCommandService {
         } else {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT);
         }
+
+        Events.trigger(
+            new UserStatusUpdatedEvent(user.getId(), request.getStatus().name())
+        );
 
         return userMapper.toResponseDto(user);
     }

--- a/src/main/java/com/followme/userserver/config/JpaAuditConfig.java
+++ b/src/main/java/com/followme/userserver/config/JpaAuditConfig.java
@@ -1,8 +1,10 @@
 package com.followme.userserver.config;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -11,6 +13,8 @@ import java.util.UUID;
 
 @Configuration
 @EnableJpaAuditing
+@EntityScan(basePackages = {"com.followme.userserver", "com.followMe.common"})
+@EnableJpaRepositories(basePackages = {"com.followme.userserver", "com.followMe.common"})
 public class JpaAuditConfig {
 
     private static final UUID SYSTEM_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");

--- a/src/main/java/com/followme/userserver/config/KafkaTopicConfig.java
+++ b/src/main/java/com/followme/userserver/config/KafkaTopicConfig.java
@@ -1,0 +1,46 @@
+package com.followme.userserver.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    // 1. 회원가입 이벤트 토픽
+    @Bean
+    public NewTopic userCreatedTopic() {
+        return TopicBuilder.name("UserCreatedEvent")
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    // 2. 유저 상태 변경 이벤트 토픽
+    @Bean
+    public NewTopic userStatusUpdatedTopic() {
+        return TopicBuilder.name("UserStatusUpdatedEvent")
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+
+    // 3. 계정 비활성화 이벤트 토픽
+    @Bean
+    public NewTopic userDeactivatedTopic() {
+        return TopicBuilder.name("UserDeactivatedEvent")
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+
+    // 4. 배송 담당자 순번 업데이트 이벤트 토픽
+    @Bean
+    public NewTopic deliverySequenceUpdatedTopic() {
+        return TopicBuilder.name("DeliverySequenceUpdatedEvent")
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+}

--- a/src/main/java/com/followme/userserver/config/OpenApiConfig.java
+++ b/src/main/java/com/followme/userserver/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.followme.userserver.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("User Service API")
+                .version("v1.0.0")
+                .description("사용자 및 배송 담당자 관리 API"));
+    }
+}

--- a/src/main/java/com/followme/userserver/config/SchedulerConfig.java
+++ b/src/main/java/com/followme/userserver/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.followme.userserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/followme/userserver/domain/event/DeliverySequenceUpdatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/DeliverySequenceUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class DeliverySequenceUpdatedEvent extends BaseEvent {
+    private final Long newSequence;
+
+    public DeliverySequenceUpdatedEvent(UUID userId, Long newSequence) {
+        super("USER", userId);
+        this.newSequence = newSequence;
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/event/UserCreatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/UserCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class UserCreatedEvent extends BaseEvent {
+    private final String username;
+    private final String role;
+
+    public UserCreatedEvent(UUID userId, String username, String role) {
+        super("USER", userId);
+        this.username = username;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/event/UserDeactivatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/UserDeactivatedEvent.java
@@ -1,0 +1,12 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class UserDeactivatedEvent extends BaseEvent {
+    public UserDeactivatedEvent(UUID userId) {
+        super("USER", userId);
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/event/UserStatusUpdatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/UserStatusUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class UserStatusUpdatedEvent extends BaseEvent {
+    private final String newStatus;
+
+    public UserStatusUpdatedEvent(UUID userId, String newStatus) {
+        super("USER", userId);
+        this.newStatus = newStatus;
+    }
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -8,6 +8,10 @@ import com.followme.userserver.application.dto.UserRequest;
 import com.followme.userserver.application.dto.UserResponse;
 import com.followme.userserver.application.service.UserCommandService;
 import com.followme.userserver.application.service.UserQueryService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -15,87 +19,66 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class UserController {
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
     @PostMapping("/register")
+    @SecurityRequirements()
     public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody UserRequest.Register request) {
-        
         userCommandService.registerUser(request);
-
         return ApiResponse.created();
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser UUID userId) {
-        
+    public ResponseEntity<ApiResponse> getMyProfile(
+            @Parameter(hidden = true) @CurrentUser UUID userId) {
         UserResponse.Info responseDto = userQueryService.getUserProfile(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse> updateMyProfile(
-            @CurrentUser UUID userId,
+            @Parameter(hidden = true) @CurrentUser UUID userId,
             @RequestBody UserRequest.UpdateProfile request) {
-
         UserResponse.Info responseDto = userCommandService.updateUserProfile(userId, request);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse> deactivateMyAccount(@CurrentUser UUID userId) {
-        
+    public ResponseEntity<ApiResponse> deactivateMyAccount(
+            @Parameter(hidden = true) @CurrentUser UUID userId) {
         userCommandService.deactivateMyAccount(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ApiResponse.ok();
     }
     
     @PatchMapping("/{userId}/status")
     public ResponseEntity<ApiResponse> updateUserStatus(
             @PathVariable UUID userId,
             @RequestBody UserRequest.UpdateStatus request) {
-        
         UserResponse.Info responseDto = userCommandService.updateUserStatus(userId, request);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse> getUserById(@PathVariable UUID userId) {
-        
         UserResponse.Info responseDto = userQueryService.getUserById(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse> getAllUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-
-        // 1. common-lib의 PageRequest를 통해 검증된 Pageable 객체 생성 (10, 30, 50 사이즈 강제)
-        Pageable pageable = PageRequest.of(page, size).toPageable();
-
+        Pageable pageable = com.followMe.common.pagination.PageRequest.of(page, size).toPageable();
         PageResponse<UserResponse.Info> responseDto = userQueryService.getAllUsers(pageable);
-
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
-
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -57,7 +57,13 @@ public class UserController {
         userCommandService.deactivateMyAccount(userId);
         return ApiResponse.ok();
     }
-    
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<ApiResponse> deactivateAccount(@PathVariable UUID userId) {
+        userCommandService.deactivateAccount(userId);
+        return ApiResponse.ok();
+    }
+
     @PatchMapping("/{userId}/status")
     public ResponseEntity<ApiResponse> updateUserStatus(
             @PathVariable UUID userId,

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.followme.userserver.presentation.controller;
 
-import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
 import com.followMe.common.response.ApiResponse;
 import com.followme.userserver.application.annotation.CurrentUser;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,14 @@ spring:
   jackson:
     default-property-inclusion: non_null
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+
 keycloak:
   server-url: http://localhost:9090
   realm: user

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
 
   jackson:
     default-property-inclusion: non_null
+
 keycloak:
   server-url: http://localhost:9090
   realm: user
@@ -36,3 +37,15 @@ keycloak:
     client-id: admin-cli
     username: admin
     password: admin
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  tracing:
+    sampling:
+      probability: 1.0 # 1.0은 100% 기록 (운영 환경에서는 부하를 위해 0.1(10%) 등으로 낮춤)
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update 
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true
@@ -30,7 +30,7 @@ spring:
     default-property-inclusion: non_null
 
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
### 📌 관련 이슈

- close #31

### 💡 작업 내용

- `docker-compose.yml` 내 Kafka 및 Zookeeper 컨테이너 구성 추가

- `user-server` 내 `spring-kafka` 의존성 주입 및 `application.yml` 프로듀서 환경 설정

- 설정 클래스 분리 및 `@EnableScheduling`, `@EntityScan` 명시적 적용

- 회원가입, 계정 비활성화, 배송 순번 업데이트 트랜잭션에 `Events.trigger()` 적용 및 도메인 이벤트 클래스 생성

### 🔍 변경 이유

- 마이크로서비스 간 안전한 비동기 통신 환경 구축 및 시스템 결합도 완화

- 서비스 상태 변경(DB 트랜잭션)과 이벤트 발행 간의 완벽한 데이터 정합성 보장

### 🧠 기타 참고 사항

- 로컬 서버 최초 기동 및 이벤트 첫 발행 시 발생하는 `LEADER_NOT_AVAILABLE` 경고는 토픽 생성에 따른 정상적인 동작