### PR TITLE
[FEAT] QueryDSL 인프라 구축 및 동적 쿼리 전용 Repository 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,32 +1,32 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.13'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'com.diffplug.spotless' version '6.25.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.13'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.diffplug.spotless' version '6.25.0'
 }
 
 group = 'com.followme'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
-	maven {
+    mavenCentral()
+    maven {
         url = uri("https://maven.pkg.github.com/8ollowMe/common-lib")
         credentials {
-            username = findProperty("gpr.user")
-            password = findProperty("gpr.key")
+            username = findProperty("gpr.user") ?: System.getenv("GPR_USER")
+            password = findProperty("gpr.key") ?: System.getenv("GPR_KEY")
         }
     }
 }
@@ -36,66 +36,61 @@ ext {
 }
 
 dependencies {
-	// 공통 라이브러리 의존성 추가
-	implementation 'com.followMe:common-lib:1.0.7' 
-
-	// Keycloak Admin Client 의존성 추가
-	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
-
-	// MapStruct 핵심 라이브러리
-    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
-    
-    // Lombok과의 공존을 위한 바인딩 (필수)
-    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
-
-	// 모니터링 및 메트릭 수집 (필수)
+    // 1. Core Framework & Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     
-    // 분산 추적 - Micrometer Tracing (Brave 브릿지 사용)
-    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-    
-    // Zipkin으로 트레이스 데이터를 전송하는 리포터
-    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    // 2. Data Access & Query Optimization
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 
-	// OpenAPI 문서화 도구
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
-
-	// Kafka & Outbox 패턴 활성화를 위한 의존성
+    // 3. Cloud & Infrastructure (Eureka, Kafka)
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.kafka:spring-kafka'
-	
-	// QueryDSL 의존성 추가 (JPA용)
-	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    implementation 'com.followMe:common-lib:1.0.7' // 최신 버전 유지
+
+    // 4. Security & Identity Management
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.keycloak:keycloak-admin-client:24.0.1'
+
+    // 5. Observability (Tracing & Metrics)
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+    // 6. Code Generation - ⚠️ 실행 순서 엄격 준수 (Lombok -> Binding -> MapStruct -> QueryDSL)
+    
+    // Step 1: Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Step 2: MapStruct & Lombok Binding (Lombok 코드를 MapStruct가 인식하기 위함)
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    // Step 3: QueryDSL (Jakarta Namespace)
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // 7. Test Suite
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testAnnotationProcessor 'org.projectlombok:lombok' // 테스트 환경에서도 Lombok 코드 생성 보장
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
     imports {
-        // 이 블록이 누락된 라이브러리의 버전을 자동으로 주입합니다.
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
-}
-
-// === QueryDSL 빌드 설정 ===
+// === QueryDSL QClass Build Configuration ===
 def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 
 sourceSets {
@@ -104,8 +99,16 @@ sourceSets {
 
 tasks.withType(JavaCompile).configureEach {
     options.getGeneratedSourceOutputDirectory().set(querydslDir)
+    // MapStruct 옵션 추가: Spring 빈으로 자동 등록
+    options.compilerArgs += [
+        "-Amapstruct.defaultComponentModel=spring"
+    ]
 }
 
 clean {
     delete querydslDir
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,11 @@ ext {
 }
 
 dependencies {
-	implementation 'com.followMe:common-lib:1.0.4' // 공통 라이브러리 의존성 추가
+	// 공통 라이브러리 의존성 추가
+	implementation 'com.followMe:common-lib:1.0.4' 
 
-	implementation 'org.keycloak:keycloak-admin-client:24.0.1' // Keycloak Admin Client 의존성 추가
+	// Keycloak Admin Client 의존성 추가
+	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
 
 	// MapStruct 핵심 라이브러리
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
@@ -46,6 +48,15 @@ dependencies {
     
     // Lombok과의 공존을 위한 바인딩 (필수)
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+	// 모니터링 및 메트릭 수집 (필수)
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // 분산 추적 - Micrometer Tracing (Brave 브릿지 사용)
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    
+    // Zipkin으로 트레이스 데이터를 전송하는 리포터
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 
 	// Kafka & Outbox 패턴 활성화를 위한 의존성
     implementation 'org.springframework.kafka:spring-kafka'
+	
+	// QueryDSL 의존성 추가 (JPA용)
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -87,4 +93,19 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// === QueryDSL 빌드 설정 ===
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+    delete querydslDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
 
 dependencies {
 	// 공통 라이브러리 의존성 추가
-	implementation 'com.followMe:common-lib:1.0.4' 
+	implementation 'com.followMe:common-lib:1.0.7' 
 
 	// Keycloak Admin Client 의존성 추가
 	implementation 'org.keycloak:keycloak-admin-client:24.0.1' 
@@ -57,6 +57,9 @@ dependencies {
     
     // Zipkin으로 트레이스 데이터를 전송하는 리포터
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
+	// OpenAPI 문서화 도구
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 	// OpenAPI 문서화 도구
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
+	// Kafka & Outbox 패턴 활성화를 위한 의존성
+    implementation 'org.springframework.kafka:spring-kafka'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,9 @@ services:
     networks:
       - keycloak-net
 
-  kafka:
+  kafka-1:
     image: confluentinc/cp-kafka:7.5.0
-    container_name: kafka
+    container_name: kafka-1
     depends_on:
       - zookeeper
     ports:
@@ -65,10 +65,53 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:29092,PLAINTEXT_HOST://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    networks:
+      - keycloak-net
+
+  kafka-2:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka-2
+    depends_on:
+      - zookeeper
+    ports:
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+    networks:
+      - keycloak-net
+
+  kafka-3:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka-3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:29094,PLAINTEXT_HOST://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     networks:
       - keycloak-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,38 @@ services:
       - '9411:9411'
     networks:
       - keycloak-net
+  
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - keycloak-net
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - keycloak-net
 
 volumes:
   postgres-keycloak-data:
   keycloak-data:
+  zookeeper-data:
+  kafka-data:
 
 networks:
   keycloak-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,19 @@ services:
     networks:
       - keycloak-net
 
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin-server
+    restart: unless-stopped
+    ports:
+      - '9411:9411'
+    networks:
+      - keycloak-net
+
 volumes:
   postgres-keycloak-data:
   keycloak-data:
 
 networks:
   keycloak-net:
+  

--- a/src/main/java/com/followme/userserver/application/dto/UserRequest.java
+++ b/src/main/java/com/followme/userserver/application/dto/UserRequest.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 
@@ -56,5 +57,13 @@ public class UserRequest {
     @Getter
     public static class UpdateStatus {
         private UserStatus status;
+    }
+
+    @Getter
+    @Setter
+    public static class SearchCondition {
+        private UserRole role;
+        private UserStatus status;
+        private String keyword;
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/InternalUserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/InternalUserCommandService.java
@@ -27,13 +27,7 @@ public class InternalUserCommandService {
             throw new IllegalArgumentException("User is not a delivery personnel.");
         }
 
-        Long currentMaxSequence = 0L;
-
-        if (user.getHubId() != null) {
-            currentMaxSequence = userRepository.findMaxSequenceByHubIdAndRole(user.getHubId(), UserRole.DELIVERY);
-        } else {
-            currentMaxSequence = userRepository.findMaxSequenceGlobalByRole(UserRole.DELIVERY);
-        }
+        Long currentMaxSequence = userRepository.findMaxSequence(user.getHubId(), UserRole.DELIVERY);
 
         user.updateSequence(currentMaxSequence + 1);
 

--- a/src/main/java/com/followme/userserver/application/service/InternalUserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/InternalUserCommandService.java
@@ -1,7 +1,9 @@
 package com.followme.userserver.application.service;
 
+import com.followMe.common.event.Events;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.event.DeliverySequenceUpdatedEvent;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +36,9 @@ public class InternalUserCommandService {
         }
 
         user.updateSequence(currentMaxSequence + 1);
+
+        Events.trigger(
+            new DeliverySequenceUpdatedEvent(user.getId(), user.getSequence())
+        );
     }
 }

--- a/src/main/java/com/followme/userserver/application/service/InternalUserQueryService.java
+++ b/src/main/java/com/followme/userserver/application/service/InternalUserQueryService.java
@@ -46,7 +46,7 @@ public class InternalUserQueryService {
 
     @Transactional(readOnly = true)
     public List<UserResponse.Internal> getManagersByHub(UUID hubId) {
-        List<User> managers = userRepository.findAllByHubIdAndRole(hubId, UserRole.HUB);
+        List<User> managers = userRepository.findManagersByHubId(hubId);
         return managers.stream()
                 .map(userMapper::toInternalResponseDto)
                 .toList();
@@ -57,13 +57,9 @@ public class InternalUserQueryService {
         List<User> deliveryUsers;
 
         if ("VENDOR".equalsIgnoreCase(type)) {
-
-            deliveryUsers = userRepository.findAllByHubIdAndRoleAndStatusOrderBySequenceAsc(
-                    nodeId, UserRole.DELIVERY, UserStatus.APPROVED);
+            deliveryUsers = userRepository.findDeliveries(null, nodeId);
         } else if ("HUB".equalsIgnoreCase(type)) {
-
-            deliveryUsers = userRepository.findAllByHubIdIsNullAndRoleAndStatusOrderBySequenceAsc(
-                    UserRole.DELIVERY, UserStatus.APPROVED);
+            deliveryUsers = userRepository.findDeliveries(nodeId, null);
         } else {
             throw new IllegalArgumentException("Unsupported NodeType: " + type);
         }

--- a/src/main/java/com/followme/userserver/application/service/InternalUserQueryService.java
+++ b/src/main/java/com/followme/userserver/application/service/InternalUserQueryService.java
@@ -3,8 +3,6 @@ package com.followme.userserver.application.service;
 import com.followme.userserver.application.dto.UserResponse;
 import com.followme.userserver.application.mapper.UserMapper;
 import com.followme.userserver.domain.entity.User;
-import com.followme.userserver.domain.enums.UserRole;
-import com.followme.userserver.domain.enums.UserStatus;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.UserNotFoundException;
 

--- a/src/main/java/com/followme/userserver/application/service/UserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserCommandService.java
@@ -50,7 +50,6 @@ public class UserCommandService {
             throw new DuplicateUsernameException();
         }
 
-        // 배송 기사(DELIVERY)는 VendorId를 가질 수 없음을 검증
         if (request.getRole() == UserRole.DELIVERY) {
             if (request.getVendorId() != null) {
                 throw new InvalidDeliveryAssociationException();
@@ -146,27 +145,15 @@ public class UserCommandService {
             authPort.syncKeycloakUserStatus(userId, true);
             authPort.assignRealmRole(userId, user.getRole().name());
 
-
             if (user.getRole() == UserRole.DELIVERY) {
-                Long currentMaxSequence = 0L;
-                
-                if (user.getHubId() != null) {
-
-                    currentMaxSequence = userRepository.findMaxSequenceByHubIdAndRole(user.getHubId(), UserRole.DELIVERY);
-                } else {
-
-                    currentMaxSequence = userRepository.findMaxSequenceGlobalByRole(UserRole.DELIVERY);
-                }
-                
+                Long currentMaxSequence = userRepository.findMaxSequence(user.getHubId(), UserRole.DELIVERY);
                 user.updateSequence(currentMaxSequence + 1);
             }
 
         } else if (request.getStatus() == UserStatus.REJECTED) {
             user.reject();
             authPort.syncKeycloakUserStatus(userId, false);
-            
             user.updateSequence(null);
-
         } else {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT);
         }

--- a/src/main/java/com/followme/userserver/application/service/UserCommandService.java
+++ b/src/main/java/com/followme/userserver/application/service/UserCommandService.java
@@ -1,5 +1,6 @@
 package com.followme.userserver.application.service;
 
+import com.followMe.common.event.Events;
 import com.followMe.common.exception.BusinessException;
 import com.followMe.common.exception.CommonErrorCode;
 import com.followme.userserver.application.dto.UserRequest;
@@ -9,6 +10,9 @@ import com.followme.userserver.application.port.AuthPort;
 import com.followme.userserver.domain.entity.User;
 import com.followme.userserver.domain.enums.UserRole;
 import com.followme.userserver.domain.enums.UserStatus;
+import com.followme.userserver.domain.event.UserCreatedEvent;
+import com.followme.userserver.domain.event.UserDeactivatedEvent;
+import com.followme.userserver.domain.event.UserStatusUpdatedEvent;
 import com.followme.userserver.domain.repository.UserRepository;
 import com.followme.userserver.exception.DuplicateUsernameException;
 import com.followme.userserver.exception.InvalidDeliveryAssociationException;
@@ -78,8 +82,12 @@ public class UserCommandService {
 
         User newUser = userMapper.toEntity(request);
         newUser.setId(UUID.fromString(keycloakUserId));
-
+        
         userRepository.save(newUser);
+
+        Events.trigger(
+            new UserCreatedEvent(newUser.getId(), newUser.getUsername(), newUser.getRole().name())
+        );
     }
 
     @Transactional
@@ -105,6 +113,27 @@ public class UserCommandService {
         } catch (Exception e) {
             throw new KeycloakSyncException(); 
         }
+
+        Events.trigger(new UserDeactivatedEvent(user.getId()));
+    }
+
+    @Transactional
+    public void deactivateAccount(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        String currentTokenUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+        user.deactivateAccount(UUID.fromString(currentTokenUserId));
+        
+        try {
+            UserRepresentation kcUser = keycloak.realm(realm).users().get(userId.toString()).toRepresentation();
+            kcUser.setEnabled(false);
+            keycloak.realm(realm).users().get(userId.toString()).update(kcUser);
+        } catch (Exception e) {
+            throw new KeycloakSyncException(); 
+        }
+
+        Events.trigger(new UserDeactivatedEvent(user.getId()));
     }
 
     @Transactional
@@ -141,6 +170,10 @@ public class UserCommandService {
         } else {
             throw new BusinessException(CommonErrorCode.INVALID_INPUT);
         }
+
+        Events.trigger(
+            new UserStatusUpdatedEvent(user.getId(), request.getStatus().name())
+        );
 
         return userMapper.toResponseDto(user);
     }

--- a/src/main/java/com/followme/userserver/config/JpaAuditConfig.java
+++ b/src/main/java/com/followme/userserver/config/JpaAuditConfig.java
@@ -1,8 +1,10 @@
 package com.followme.userserver.config;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -11,6 +13,8 @@ import java.util.UUID;
 
 @Configuration
 @EnableJpaAuditing
+@EntityScan(basePackages = {"com.followme.userserver", "com.followMe.common"})
+@EnableJpaRepositories(basePackages = {"com.followme.userserver", "com.followMe.common"})
 public class JpaAuditConfig {
 
     private static final UUID SYSTEM_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");

--- a/src/main/java/com/followme/userserver/config/KafkaTopicConfig.java
+++ b/src/main/java/com/followme/userserver/config/KafkaTopicConfig.java
@@ -1,0 +1,46 @@
+package com.followme.userserver.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    // 1. 회원가입 이벤트 토픽
+    @Bean
+    public NewTopic userCreatedTopic() {
+        return TopicBuilder.name("UserCreatedEvent")
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    // 2. 유저 상태 변경 이벤트 토픽
+    @Bean
+    public NewTopic userStatusUpdatedTopic() {
+        return TopicBuilder.name("UserStatusUpdatedEvent")
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+
+    // 3. 계정 비활성화 이벤트 토픽
+    @Bean
+    public NewTopic userDeactivatedTopic() {
+        return TopicBuilder.name("UserDeactivatedEvent")
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+
+    // 4. 배송 담당자 순번 업데이트 이벤트 토픽
+    @Bean
+    public NewTopic deliverySequenceUpdatedTopic() {
+        return TopicBuilder.name("DeliverySequenceUpdatedEvent")
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+}

--- a/src/main/java/com/followme/userserver/config/OpenApiConfig.java
+++ b/src/main/java/com/followme/userserver/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.followme.userserver.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("User Service API")
+                .version("v1.0.0")
+                .description("사용자 및 배송 담당자 관리 API"));
+    }
+}

--- a/src/main/java/com/followme/userserver/config/QueryDslConfig.java
+++ b/src/main/java/com/followme/userserver/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.followme.userserver.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/followme/userserver/config/SchedulerConfig.java
+++ b/src/main/java/com/followme/userserver/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.followme.userserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/followme/userserver/domain/event/DeliverySequenceUpdatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/DeliverySequenceUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class DeliverySequenceUpdatedEvent extends BaseEvent {
+    private final Long newSequence;
+
+    public DeliverySequenceUpdatedEvent(UUID userId, Long newSequence) {
+        super("USER", userId);
+        this.newSequence = newSequence;
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/event/UserCreatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/UserCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class UserCreatedEvent extends BaseEvent {
+    private final String username;
+    private final String role;
+
+    public UserCreatedEvent(UUID userId, String username, String role) {
+        super("USER", userId);
+        this.username = username;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/event/UserDeactivatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/UserDeactivatedEvent.java
@@ -1,0 +1,12 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class UserDeactivatedEvent extends BaseEvent {
+    public UserDeactivatedEvent(UUID userId) {
+        super("USER", userId);
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/event/UserStatusUpdatedEvent.java
+++ b/src/main/java/com/followme/userserver/domain/event/UserStatusUpdatedEvent.java
@@ -1,0 +1,15 @@
+package com.followme.userserver.domain.event;
+
+import com.followMe.common.event.BaseEvent;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+public class UserStatusUpdatedEvent extends BaseEvent {
+    private final String newStatus;
+
+    public UserStatusUpdatedEvent(UUID userId, String newStatus) {
+        super("USER", userId);
+        this.newStatus = newStatus;
+    }
+}

--- a/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
+++ b/src/main/java/com/followme/userserver/domain/repository/UserRepository.java
@@ -1,33 +1,12 @@
 package com.followme.userserver.domain.repository;
 
 import com.followme.userserver.domain.entity.User;
-import com.followme.userserver.domain.enums.UserRole;
-import com.followme.userserver.domain.enums.UserStatus;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
-    
+public interface UserRepository extends JpaRepository<User, UUID>, UserRepositoryCustom {
     boolean existsByUsername(String username);
-
     Optional<User> findByUsername(String username);
-
-    List<User> findAllByHubIdAndRole(UUID hubId, UserRole role);
-
-
-    List<User> findAllByHubIdAndRoleAndStatusOrderBySequenceAsc(UUID hubId, UserRole role, UserStatus status);
-    
-    List<User> findAllByHubIdIsNullAndRoleAndStatusOrderBySequenceAsc(UserRole role, UserStatus status);
-
-    @Query("SELECT COALESCE(MAX(u.sequence), 0L) FROM User u WHERE u.hubId = :hubId AND u.role = :role")
-    Long findMaxSequenceByHubIdAndRole(@Param("hubId") UUID hubId, @Param("role") UserRole role);
-
-    @Query("SELECT COALESCE(MAX(u.sequence), 0L) FROM User u WHERE u.hubId IS NULL AND u.role = :role")
-    Long findMaxSequenceGlobalByRole(@Param("role") UserRole role);
 }

--- a/src/main/java/com/followme/userserver/domain/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/followme/userserver/domain/repository/UserRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.followme.userserver.domain.repository;
+
+import com.followme.userserver.application.dto.UserRequest;
+import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserRole;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserRepositoryCustom {
+    Page<User> searchUsers(UserRequest.SearchCondition condition, Pageable pageable);
+    List<User> findManagersByHubId(UUID hubId);
+    List<User> findDeliveries(UUID hubId, UUID vendorId);
+    Long findMaxSequence(UUID hubId, UserRole role);
+}

--- a/src/main/java/com/followme/userserver/domain/repository/implement/UserRepositoryImpl.java
+++ b/src/main/java/com/followme/userserver/domain/repository/implement/UserRepositoryImpl.java
@@ -1,0 +1,120 @@
+package com.followme.userserver.domain.repository.implement;
+
+import com.followme.userserver.application.dto.UserRequest;
+import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.enums.UserStatus;
+import com.followme.userserver.domain.repository.UserRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.followme.userserver.domain.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<User> searchUsers(UserRequest.SearchCondition condition, Pageable pageable) {
+        List<User> users = queryFactory
+                .selectFrom(user)
+                .where(
+                        roleEq(condition.getRole()),
+                        statusEq(condition.getStatus()),
+                        keywordContains(condition.getKeyword()),
+                        user.deletedAt.isNull()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(user.createdAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(user.count())
+                .from(user)
+                .where(
+                        roleEq(condition.getRole()),
+                        statusEq(condition.getStatus()),
+                        keywordContains(condition.getKeyword()),
+                        user.deletedAt.isNull()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(users, pageable, total == null ? 0 : total);
+    }
+
+    @Override
+    public List<User> findManagersByHubId(UUID hubId) {
+        return queryFactory
+                .selectFrom(user)
+                .where(
+                        hubIdEq(hubId),
+                        user.role.in(UserRole.HUB, UserRole.MASTER),
+                        user.deletedAt.isNull()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<User> findDeliveries(UUID hubId, UUID vendorId) {
+        return queryFactory
+                .selectFrom(user)
+                .where(
+                        user.role.eq(UserRole.DELIVERY),
+                        hubIdEq(hubId),
+                        vendorIdEq(vendorId),
+                        user.deletedAt.isNull()
+                )
+                .orderBy(user.sequence.asc().nullsLast())
+                .fetch();
+    }
+
+    @Override
+    public Long findMaxSequence(UUID hubId, UserRole role) {
+        Long maxSeq = queryFactory
+                .select(user.sequence.max())
+                .from(user)
+                .where(
+                        hubIdEq(hubId), // Null일 경우 isNull 조건으로 동작
+                        roleEq(role),
+                        user.deletedAt.isNull()
+                )
+                .fetchOne();
+
+        return maxSeq == null ? 0L : maxSeq;
+    }
+
+    // --- 동적 쿼리 조건 생성 메서드 ---
+
+    private BooleanExpression roleEq(UserRole role) {
+        return role != null ? user.role.eq(role) : null;
+    }
+
+    private BooleanExpression statusEq(UserStatus status) {
+        return status != null ? user.status.eq(status) : null;
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return (keyword != null && !keyword.isBlank())
+                ? user.name.containsIgnoreCase(keyword).or(user.username.containsIgnoreCase(keyword))
+                : null;
+    }
+
+    private BooleanExpression hubIdEq(UUID hubId) {
+        return hubId != null ? user.hubId.eq(hubId) : user.hubId.isNull();
+    }
+
+    private BooleanExpression vendorIdEq(UUID vendorId) {
+        return vendorId != null ? user.vendorId.eq(vendorId) : null;
+    }
+}

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -8,6 +8,10 @@ import com.followme.userserver.application.dto.UserRequest;
 import com.followme.userserver.application.dto.UserResponse;
 import com.followme.userserver.application.service.UserCommandService;
 import com.followme.userserver.application.service.UserQueryService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -15,87 +19,66 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class UserController {
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
     @PostMapping("/register")
+    @SecurityRequirements()
     public ResponseEntity<ApiResponse> registerUser(@Valid @RequestBody UserRequest.Register request) {
-        
         userCommandService.registerUser(request);
-
         return ApiResponse.created();
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse> getMyProfile(@CurrentUser UUID userId) {
-        
+    public ResponseEntity<ApiResponse> getMyProfile(
+            @Parameter(hidden = true) @CurrentUser UUID userId) {
         UserResponse.Info responseDto = userQueryService.getUserProfile(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse> updateMyProfile(
-            @CurrentUser UUID userId,
+            @Parameter(hidden = true) @CurrentUser UUID userId,
             @RequestBody UserRequest.UpdateProfile request) {
-
         UserResponse.Info responseDto = userCommandService.updateUserProfile(userId, request);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse> deactivateMyAccount(@CurrentUser UUID userId) {
-        
+    public ResponseEntity<ApiResponse> deactivateMyAccount(
+            @Parameter(hidden = true) @CurrentUser UUID userId) {
         userCommandService.deactivateMyAccount(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ApiResponse.ok();
     }
     
     @PatchMapping("/{userId}/status")
     public ResponseEntity<ApiResponse> updateUserStatus(
             @PathVariable UUID userId,
             @RequestBody UserRequest.UpdateStatus request) {
-        
         UserResponse.Info responseDto = userCommandService.updateUserStatus(userId, request);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse> getUserById(@PathVariable UUID userId) {
-        
         UserResponse.Info responseDto = userQueryService.getUserById(userId);
-        
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse> getAllUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-
-        // 1. common-lib의 PageRequest를 통해 검증된 Pageable 객체 생성 (10, 30, 50 사이즈 강제)
-        Pageable pageable = PageRequest.of(page, size).toPageable();
-
+        Pageable pageable = com.followMe.common.pagination.PageRequest.of(page, size).toPageable();
         PageResponse<UserResponse.Info> responseDto = userQueryService.getAllUsers(pageable);
-
-        return ResponseEntity.ok(ApiResponse.success(responseDto));
+        return ApiResponse.ok(responseDto);
     }
-
 }

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -57,7 +57,13 @@ public class UserController {
         userCommandService.deactivateMyAccount(userId);
         return ApiResponse.ok();
     }
-    
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<ApiResponse> deactivateAccount(@PathVariable UUID userId) {
+        userCommandService.deactivateAccount(userId);
+        return ApiResponse.ok();
+    }
+
     @PatchMapping("/{userId}/status")
     public ResponseEntity<ApiResponse> updateUserStatus(
             @PathVariable UUID userId,

--- a/src/main/java/com/followme/userserver/presentation/controller/UserController.java
+++ b/src/main/java/com/followme/userserver/presentation/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.followme.userserver.presentation.controller;
 
-import com.followMe.common.pagination.PageRequest;
 import com.followMe.common.pagination.PageResponse;
 import com.followMe.common.response.ApiResponse;
 import com.followme.userserver.application.annotation.CurrentUser;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,14 @@ spring:
   jackson:
     default-property-inclusion: non_null
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+
 keycloak:
   server-url: http://localhost:9090
   realm: user

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ spring:
 
   jackson:
     default-property-inclusion: non_null
+
 keycloak:
   server-url: http://localhost:9090
   realm: user
@@ -36,3 +37,15 @@ keycloak:
     client-id: admin-cli
     username: admin
     password: admin
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  tracing:
+    sampling:
+      probability: 1.0 # 1.0은 100% 기록 (운영 환경에서는 부하를 위해 0.1(10%) 등으로 낮춤)
+  zipkin:
+    tracing:
+      endpoint: "http://localhost:9411/api/v2/spans"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update 
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true
@@ -30,7 +30,7 @@ spring:
     default-property-inclusion: non_null
 
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
📌 관련 이슈
- close #33

💡 작업 내용
- build.gradle 내 QueryDSL 관련 라이브러리 및 QClass 컴파일 환경 구성

- QueryDslConfig를 통한 JPAQueryFactory 스프링 빈 등록

- UserRepositoryCustom 인터페이스 및 implement 패키지 하위에 UserRepositoryImpl 구현체 분리

- 다중 조건 검색(searchUsers) 및 시퀀스 집계 로직 등을 QueryDSL 기반 동적 쿼리로 리팩토링 및 서비스 계층 연동

🔍 변경 이유
- 복잡한 다중 필터링 요구사항을 기존 JPA 메서드 네이밍 규칙이나 @Query 문자열로 처리하는 데 따른 유지보수 한계 극복

- 문자열이 아닌 타입 세이프(Type-Safe)한 자바 코드로 쿼리를 작성하여 컴파일 타임에 오류를 감지, 시스템 안정성 확보

🧠 기타 참고 사항
- 로컬 환경 테스트 시 먼저 ./gradlew clean compileJava를 실행하여 QClass(QUser 등) 생성이 선행되어야 정상 작동함