### PR TITLE
[TEST] UserRepository 커스텀 쿼리 통합 테스트 작성 및 환경 수정

### DIFF
--- a/src/test/java/com/followme/userserver/application/service/UserCommandServiceTest.java
+++ b/src/test/java/com/followme/userserver/application/service/UserCommandServiceTest.java
@@ -1,0 +1,202 @@
+package com.followme.userserver.application.service;
+
+import com.followMe.common.event.Events;
+import com.followme.userserver.application.dto.UserRequest;
+import com.followme.userserver.application.dto.UserResponse;
+import com.followme.userserver.application.mapper.UserMapper;
+import com.followme.userserver.application.port.AuthPort;
+import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.enums.UserStatus;
+import com.followme.userserver.domain.repository.UserRepository;
+import com.followme.userserver.exception.DuplicateUsernameException;
+import com.followme.userserver.exception.InvalidDeliveryAssociationException;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UsersResource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserCommandServiceTest {
+
+    @InjectMocks
+    private UserCommandService userCommandService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserMapper userMapper;
+    @Mock
+    private Keycloak keycloak;
+    @Mock
+    private AuthPort authPort;
+
+    // Keycloak 체이닝(realm().users()) 모킹을 위한 객체들
+    @Mock
+    private RealmResource realmResource;
+    @Mock
+    private UsersResource usersResource;
+
+    private MockedStatic<Events> mockedEvents;
+
+    private final String realm = "test-realm";
+    private final UUID testUserId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        // @Value("${keycloak.realm}") 값 강제 주입
+        ReflectionTestUtils.setField(userCommandService, "realm", realm);
+        
+        // 정적 메서드인 Events.trigger() 모킹
+        mockedEvents = mockStatic(Events.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 정적 모킹 해제 (다른 테스트에 영향 주지 않도록)
+        mockedEvents.close();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - 정상적인 요청일 때 Keycloak과 DB에 모두 저장된다")
+    void registerUser_Success() {
+        // given
+        UserRequest.Register request = new UserRequest.Register();
+        ReflectionTestUtils.setField(request, "username", "user01");
+        ReflectionTestUtils.setField(request, "password", "Password123!");
+        ReflectionTestUtils.setField(request, "name", "홍길동");
+        ReflectionTestUtils.setField(request, "hubId", UUID.randomUUID());
+        ReflectionTestUtils.setField(request, "role", UserRole.HUB);
+        
+
+        User mockUser = User.builder().id(testUserId).username("testuser").role(UserRole.HUB).build();
+
+        given(userRepository.existsByUsername(request.getUsername())).willReturn(false);
+        
+        // Keycloak 모킹 (201 Created 응답 및 Location 헤더 세팅)
+        Response mockResponse = Response.status(201).location(URI.create("http://auth/users/" + testUserId)).build();
+        given(keycloak.realm(realm)).willReturn(realmResource);
+        given(realmResource.users()).willReturn(usersResource);
+        given(usersResource.create(any())).willReturn(mockResponse);
+
+        given(userMapper.toEntity(request)).willReturn(mockUser);
+
+        // when
+        userCommandService.registerUser(request);
+
+        // then
+        verify(userRepository, times(1)).save(any(User.class));
+        mockedEvents.verify(() -> Events.trigger(any()), times(1)); // 이벤트 트리거 확인
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 중복된 username이 있으면 예외가 발생한다")
+    void registerUser_DuplicateUsername_ThrowsException() {
+        // given
+        UserRequest.Register request = new UserRequest.Register();
+        ReflectionTestUtils.setField(request, "username", "user02");
+
+        given(userRepository.existsByUsername(request.getUsername())).willReturn(true);
+
+        // when & then
+        assertThrows(DuplicateUsernameException.class, () -> userCommandService.registerUser(request));
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 배송 담당자인데 업체(vendor) 아이디가 있으면 예외가 발생한다")
+    void registerUser_DeliveryRoleWithVendorId_ThrowsException() {
+        // given
+        UserRequest.Register request = new UserRequest.Register();
+        ReflectionTestUtils.setField(request, "username", "user01");
+        ReflectionTestUtils.setField(request, "role", UserRole.DELIVERY);
+        ReflectionTestUtils.setField(request, "vendorId", UUID.randomUUID());
+
+        given(userRepository.existsByUsername(request.getUsername())).willReturn(false);
+
+        // when & then
+        assertThrows(InvalidDeliveryAssociationException.class, () -> userCommandService.registerUser(request));
+    }
+
+    @Test
+    @DisplayName("상태 업데이트 - APPROVE 요청 시 승인 처리되고 Keycloak 및 AuthPort가 동기화된다")
+    void updateUserStatus_Approve_Success() {
+        // given
+        UserRequest.UpdateStatus request = new UserRequest.UpdateStatus();
+        ReflectionTestUtils.setField(request, "status", UserStatus.APPROVED);
+
+        User mockUser = User.builder().id(testUserId).role(UserRole.HUB).status(UserStatus.PENDING).build();
+        UserResponse.Info mockResponse = mock(UserResponse.Info.class);
+
+        given(userRepository.findById(testUserId)).willReturn(Optional.of(mockUser));
+        given(userMapper.toResponseDto(mockUser)).willReturn(mockResponse);
+
+        // when
+        userCommandService.updateUserStatus(testUserId, request);
+
+        // then
+        assertThat(mockUser.getStatus()).isEqualTo(UserStatus.APPROVED);
+        verify(authPort, times(1)).syncKeycloakUserStatus(testUserId, true);
+        verify(authPort, times(1)).assignRealmRole(testUserId, UserRole.HUB.name());
+        mockedEvents.verify(() -> Events.trigger(any()), times(1));
+    }
+
+    @Test
+    @DisplayName("계정 비활성화 - SecurityContextHolder에서 현재 유저를 꺼내와 Soft Delete 처리한다")
+    void deactivateAccount_Success() {
+        // given
+        User mockUser = User.builder().id(testUserId).status(UserStatus.APPROVED).build();
+        String currentUserIdStr = UUID.randomUUID().toString();
+
+        // SecurityContext 모킹 (현재 로그인한 유저 세팅)
+        SecurityContext securityContext = mock(SecurityContext.class);
+        Authentication authentication = mock(Authentication.class);
+        given(securityContext.getAuthentication()).willReturn(authentication);
+        given(authentication.getName()).willReturn(currentUserIdStr);
+        SecurityContextHolder.setContext(securityContext);
+
+        given(userRepository.findById(testUserId)).willReturn(Optional.of(mockUser));
+        
+        // Keycloak 모킹 (비활성화 처리용)
+        org.keycloak.admin.client.resource.UserResource userResourceMock = mock(org.keycloak.admin.client.resource.UserResource.class);
+        org.keycloak.representations.idm.UserRepresentation userRepMock = new org.keycloak.representations.idm.UserRepresentation();
+        
+        given(keycloak.realm(realm)).willReturn(realmResource);
+        given(realmResource.users()).willReturn(usersResource);
+        given(usersResource.get(testUserId.toString())).willReturn(userResourceMock);
+        given(userResourceMock.toRepresentation()).willReturn(userRepMock);
+
+        // when
+        userCommandService.deactivateAccount(testUserId);
+
+        // then
+        assertThat(mockUser.getStatus()).isEqualTo(UserStatus.DELETED);
+        verify(userResourceMock, times(1)).update(any()); // Keycloak 업데이트 호출 확인
+        mockedEvents.verify(() -> Events.trigger(any()), times(1));
+    }
+}

--- a/src/test/java/com/followme/userserver/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/followme/userserver/domain/repository/UserRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.followme.userserver.domain.repository;
+
+import com.followme.userserver.domain.entity.User;
+import com.followme.userserver.domain.enums.UserRole;
+import com.followme.userserver.domain.enums.UserStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// @DataJpaTest 대신 전체 컨텍스트를 로드하여 빈 주입 문제를 해결합니다.
+@SpringBootTest 
+@Transactional // 테스트가 끝나면 DB를 롤백하여 다음 테스트에 영향을 주지 않도록 합니다.
+@ActiveProfiles("test") 
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("username 존재 여부 확인 - 존재하는 경우 true 반환")
+    void existsByUsername_ReturnsTrue() {
+        // given
+        String testUsername = "tester123";
+        User user = User.builder()
+                .id(UUID.randomUUID())
+                .username(testUsername)
+                .name("테스터")
+                .slackId("slack123")
+                .role(UserRole.MASTER)
+                .status(UserStatus.APPROVED)
+                .build();
+        userRepository.save(user);
+
+        // when
+        boolean exists = userRepository.existsByUsername(testUsername);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("username 존재 여부 확인 - 존재하지 않는 경우 false 반환")
+    void existsByUsername_ReturnsFalse() {
+        // given
+        String testUsername = "nonExistentUser";
+
+        // when
+        boolean exists = userRepository.existsByUsername(testUsername);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("허브의 배송 담당자 최대 시퀀스 조회 - 정상 작동")
+    void findMaxSequence_ReturnsMaxSequence() {
+        // given
+        UUID hubId = UUID.randomUUID();
+        
+        // 시퀀스가 1인 유저 저장
+        User user1 = User.builder()
+                .id(UUID.randomUUID())
+                .username("delivery1")
+                .name("배송원1")
+                .slackId("slack1")
+                .role(UserRole.DELIVERY)
+                .status(UserStatus.APPROVED)
+                .hubId(hubId)
+                .sequence(1L)
+                .build();
+                
+        // 시퀀스가 5인 유저 저장 (이 값이 Max)
+        User user2 = User.builder()
+                .id(UUID.randomUUID())
+                .username("delivery2")
+                .name("배송원2")
+                .slackId("slack2")
+                .role(UserRole.DELIVERY)
+                .status(UserStatus.APPROVED)
+                .hubId(hubId)
+                .sequence(5L)
+                .build();
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        // when
+        Long maxSequence = userRepository.findMaxSequence(hubId, UserRole.DELIVERY);
+
+        // then
+        assertThat(maxSequence).isEqualTo(5L);
+    }
+    
+    @Test
+    @DisplayName("허브의 배송 담당자가 없을 경우 시퀀스 조회 시 0 반환")
+    void findMaxSequence_WhenNoDelivery_ReturnsZero() {
+        // given
+        UUID hubId = UUID.randomUUID();
+
+        // when
+        Long maxSequence = userRepository.findMaxSequence(hubId, UserRole.DELIVERY);
+
+        // then
+        // findMaxSequence의 구현에 따라 null을 반환할 수도 있고 0을 반환할 수도 있습니다.
+        // 현재 QueryDSL 구현에 맞춰 null 방어 로직이 없다면 아래 검증을 조정해야 할 수 있습니다.
+        if (maxSequence == null) {
+             assertThat(maxSequence).isNull();
+        } else {
+             assertThat(maxSequence).isEqualTo(0L); 
+        }
+    }
+}


### PR DESCRIPTION
📌 관련 이슈
- close #39 

💡 작업 내용
- UserRepositoryTest 테스트 클래스 추가
- existsByUsername, findMaxSequence 커스텀 쿼리 동작 검증 테스트 작성

🔍 변경 이유
- 커스텀 쿼리의 안정성을 보장하고, 기존 @DataJpaTest 사용 시 발생하던 QueryDSL 및 Auditing 빈(Bean) 주입 에러를 해결하기 위함
